### PR TITLE
Initialize Quarkus API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Clair Obscur API
+
+This project uses **Quarkus** to expose a simple REST API.
+
+Included extensions:
+
+- RESTEasy Reactive (`quarkus-rest`)
+- SmallRye OpenAPI for Swagger UI
+- Hibernate ORM with Panache
+- MariaDB JDBC driver
+- OIDC for Keycloak integration
+- SmallRye Health for MicroProfile compatibility
+
+A simple `HelloResource` is provided at `/hello`.

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.npcirl</groupId>
-  <artifactId>npc-irl-companion</artifactId>
+  <groupId>com.opyruso.coh</groupId>
+  <artifactId>clairobscurhelper-api</artifactId>
   <version>1.0.0-SNAPSHOT</version>
 
   <properties>
@@ -95,6 +95,20 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-mariadb</artifactId>
+    </dependency>
+
+    <!-- OpenAPI and Keycloak -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-openapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-oidc</artifactId>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/opyruso/coh/HelloResource.java
+++ b/src/main/java/com/opyruso/coh/HelloResource.java
@@ -1,0 +1,16 @@
+package com.opyruso.coh;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello";
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,16 @@
+quarkus:
+  datasource:
+    db-kind: mariadb
+    username: coh_dev
+    password: coh_dev_password
+    jdbc:
+      url: jdbc:mariadb://localhost:3306/coh_dev
+  oidc:
+    auth-server-url: http://localhost:8080/realms/quarkus
+    client-id: my-client
+    credentials:
+      secret: my-secret
+  smallrye-openapi:
+    info:
+      title: Clair Obscur API
+      version: 1.0.0


### PR DESCRIPTION
## Summary
- set Maven `artifactId` to `clairobscurhelper-api`
- add SmallRye Health extension for MicroProfile support
- document health extension in README

## Testing
- `mvn -q test` *(fails to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c3e70cf60832ca168f02ff0dc7bbd