### PR TITLE
Add admin endpoints for managing pictos

### DIFF
--- a/src/main/java/com/opyruso/coh/entity/Picto.java
+++ b/src/main/java/com/opyruso/coh/entity/Picto.java
@@ -1,0 +1,35 @@
+package com.opyruso.coh.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "picto")
+public class Picto extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "id_picto")
+    public String idPicto;
+
+    @Column(name = "level")
+    public int level;
+
+    @Column(name = "bonus_defense")
+    public int bonusDefense;
+
+    @Column(name = "bonus_speed")
+    public int bonusSpeed;
+
+    @Column(name = "bonus_crit_chance")
+    public int bonusCritChance;
+
+    @Column(name = "bonus_health")
+    public int bonusHealth;
+
+    @Column(name = "lumina_cost")
+    public int luminaCost;
+
+    @OneToMany(mappedBy = "picto", cascade = CascadeType.ALL, orphanRemoval = true)
+    public List<PictoDetails> details;
+}

--- a/src/main/java/com/opyruso/coh/entity/PictoDetails.java
+++ b/src/main/java/com/opyruso/coh/entity/PictoDetails.java
@@ -1,0 +1,53 @@
+package com.opyruso.coh.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "picto_details")
+@IdClass(PictoDetails.PK.class)
+public class PictoDetails extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "id_picto")
+    public String idPicto;
+
+    @Id
+    @Column(name = "lang")
+    public String lang;
+
+    @Column(name = "name")
+    public String name;
+
+    @Column(name = "region")
+    public String region;
+
+    @Column(name = "descrption_bonus_lumina")
+    public String descrptionBonusLumina;
+
+    @Column(name = "unlock_description")
+    public String unlockDescription;
+
+    @ManyToOne
+    @JoinColumn(name = "id_picto", insertable = false, updatable = false)
+    public Picto picto;
+
+    public static class PK implements Serializable {
+        public String idPicto;
+        public String lang;
+
+        @Override
+        public int hashCode() {
+            return (idPicto + "#" + lang).hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            PK other = (PK) obj;
+            return idPicto.equals(other.idPicto) && lang.equals(other.lang);
+        }
+    }
+}

--- a/src/main/java/com/opyruso/coh/repository/PictoDetailsRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/PictoDetailsRepository.java
@@ -1,9 +1,9 @@
 package com.opyruso.coh.repository;
 
 import com.opyruso.coh.entity.PictoDetails;
-import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
-public class PictoDetailsRepository implements PanacheRepository<PictoDetails> {
+public class PictoDetailsRepository implements PanacheRepositoryBase<PictoDetails, PictoDetails.PK> {
 }

--- a/src/main/java/com/opyruso/coh/repository/PictoDetailsRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/PictoDetailsRepository.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.repository;
+
+import com.opyruso.coh.entity.PictoDetails;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PictoDetailsRepository implements PanacheRepository<PictoDetails> {
+}

--- a/src/main/java/com/opyruso/coh/repository/PictoRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/PictoRepository.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.repository;
+
+import com.opyruso.coh.entity.Picto;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PictoRepository implements PanacheRepository<Picto> {
+}

--- a/src/main/java/com/opyruso/coh/repository/PictoRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/PictoRepository.java
@@ -1,9 +1,9 @@
 package com.opyruso.coh.repository;
 
 import com.opyruso.coh.entity.Picto;
-import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
-public class PictoRepository implements PanacheRepository<Picto> {
+public class PictoRepository implements PanacheRepositoryBase<Picto, String> {
 }

--- a/src/main/java/com/opyruso/coh/resource/AdminPictoResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminPictoResource.java
@@ -1,0 +1,62 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.Picto;
+import com.opyruso.coh.repository.PictoRepository;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/admin/pictos")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class AdminPictoResource {
+
+    @Inject
+    PictoRepository repository;
+
+    @POST
+    @RolesAllowed("coh-app:admin")
+    @Transactional
+    public Response create(Picto picto) {
+        repository.persist(picto);
+        return Response.status(Response.Status.CREATED).entity(picto).build();
+    }
+
+    @PUT
+    @Path("{id}")
+    @RolesAllowed("coh-app:admin")
+    @Transactional
+    public Response update(@PathParam("id") String id, Picto picto) {
+        Picto entity = repository.findById(id);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        entity.level = picto.level;
+        entity.bonusDefense = picto.bonusDefense;
+        entity.bonusSpeed = picto.bonusSpeed;
+        entity.bonusCritChance = picto.bonusCritChance;
+        entity.bonusHealth = picto.bonusHealth;
+        entity.luminaCost = picto.luminaCost;
+        entity.details.clear();
+        if (picto.details != null) {
+            picto.details.forEach(d -> d.idPicto = id);
+            entity.details.addAll(picto.details);
+        }
+        return Response.ok(entity).build();
+    }
+
+    @DELETE
+    @Path("{id}")
+    @RolesAllowed("coh-app:admin")
+    @Transactional
+    public Response delete(@PathParam("id") String id) {
+        boolean deleted = repository.deleteById(id);
+        if (!deleted) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.noContent().build();
+    }
+}


### PR DESCRIPTION
## Summary
- add `Picto` and `PictoDetails` entities to map picto tables
- create repositories for the new entities
- implement `/admin/pictos` admin resource with create/update/delete

## Testing
- `mvn -q test -DskipTests` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687caa72b838832caae85ea1d8b23125