### PR TITLE
Enable CORS and monitoring endpoints

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,15 @@ quarkus.vertx.web-client.enable=true
 
 quarkus.oidc.auth-server-url=https://auth.opyruso.com/realms/development
 quarkus.oidc.client-id=coh-app
+
+# HTTP CORS configuration
+quarkus.http.cors=true
+quarkus.http.cors.origins=http://localhost,https://pictos-dev.opyruso.com,https://pictos-rec.opyruso.com,https://pictos.opyruso.com
+
+# Swagger UI always available
+quarkus.swagger-ui.always-include=true
+
+# Expose health endpoints at /health and liveness at /live
+quarkus.smallrye-health.root-path=/
+quarkus.smallrye-health.health-path=/health
+quarkus.smallrye-health.liveness-path=/live


### PR DESCRIPTION
## Summary
- allow CORS for localhost and `pictos` domains
- keep Swagger UI available in production
- expose health endpoints at `/health` and `/live`

## Testing
- `mvn -q -DskipTests package` *(fails: dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_687d4650fa48832ca93d1730c90ca468