### PR TITLE
Add admin endpoints for core entities

### DIFF
--- a/src/main/java/com/opyruso/coh/repository/CharacterRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/CharacterRepository.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.repository;
+
+import com.opyruso.coh.entity.Character;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CharacterRepository implements PanacheRepositoryBase<Character, String> {
+}

--- a/src/main/java/com/opyruso/coh/repository/DamageBuffTypeRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/DamageBuffTypeRepository.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.repository;
+
+import com.opyruso.coh.entity.DamageBuffType;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DamageBuffTypeRepository implements PanacheRepositoryBase<DamageBuffType, Integer> {
+}

--- a/src/main/java/com/opyruso/coh/repository/DamageTypeRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/DamageTypeRepository.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.repository;
+
+import com.opyruso.coh.entity.DamageType;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DamageTypeRepository implements PanacheRepositoryBase<DamageType, Integer> {
+}

--- a/src/main/java/com/opyruso/coh/resource/AdminCharacterResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCharacterResource.java
@@ -1,7 +1,7 @@
 package com.opyruso.coh.resource;
 
-import com.opyruso.coh.entity.Picto;
-import com.opyruso.coh.repository.PictoRepository;
+import com.opyruso.coh.entity.Character;
+import com.opyruso.coh.repository.CharacterRepository;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -9,41 +9,34 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-@Path("/admin/pictos")
+@Path("/admin/characters")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public class AdminPictoResource {
+public class AdminCharacterResource {
 
     @Inject
-    PictoRepository repository;
+    CharacterRepository repository;
 
     @POST
     @RolesAllowed("coh-app:admin")
     @Transactional
-    public Response create(Picto picto) {
-        repository.persist(picto);
-        return Response.status(Response.Status.CREATED).entity(picto).build();
+    public Response create(Character character) {
+        repository.persist(character);
+        return Response.status(Response.Status.CREATED).entity(character).build();
     }
 
     @PUT
     @RolesAllowed("coh-app:admin")
     @Transactional
-    public Response update(Picto picto) {
-        String id = picto.idPicto;
-        Picto entity = repository.findById(id);
+    public Response update(Character character) {
+        Character entity = repository.findById(character.idCharacter);
         if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        entity.level = picto.level;
-        entity.bonusDefense = picto.bonusDefense;
-        entity.bonusSpeed = picto.bonusSpeed;
-        entity.bonusCritChance = picto.bonusCritChance;
-        entity.bonusHealth = picto.bonusHealth;
-        entity.luminaCost = picto.luminaCost;
         entity.details.clear();
-        if (picto.details != null) {
-            picto.details.forEach(d -> d.idPicto = id);
-            entity.details.addAll(picto.details);
+        if (character.details != null) {
+            character.details.forEach(d -> d.idCharacter = character.idCharacter);
+            entity.details.addAll(character.details);
         }
         return Response.ok(entity).build();
     }

--- a/src/main/java/com/opyruso/coh/resource/AdminDamageBuffTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminDamageBuffTypeResource.java
@@ -1,7 +1,7 @@
 package com.opyruso.coh.resource;
 
-import com.opyruso.coh.entity.Picto;
-import com.opyruso.coh.repository.PictoRepository;
+import com.opyruso.coh.entity.DamageBuffType;
+import com.opyruso.coh.repository.DamageBuffTypeRepository;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -9,41 +9,34 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-@Path("/admin/pictos")
+@Path("/admin/damageBuffTypes")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public class AdminPictoResource {
+public class AdminDamageBuffTypeResource {
 
     @Inject
-    PictoRepository repository;
+    DamageBuffTypeRepository repository;
 
     @POST
     @RolesAllowed("coh-app:admin")
     @Transactional
-    public Response create(Picto picto) {
-        repository.persist(picto);
-        return Response.status(Response.Status.CREATED).entity(picto).build();
+    public Response create(DamageBuffType damageBuffType) {
+        repository.persist(damageBuffType);
+        return Response.status(Response.Status.CREATED).entity(damageBuffType).build();
     }
 
     @PUT
     @RolesAllowed("coh-app:admin")
     @Transactional
-    public Response update(Picto picto) {
-        String id = picto.idPicto;
-        Picto entity = repository.findById(id);
+    public Response update(DamageBuffType damageBuffType) {
+        DamageBuffType entity = repository.findById(damageBuffType.idDamageBuffType);
         if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        entity.level = picto.level;
-        entity.bonusDefense = picto.bonusDefense;
-        entity.bonusSpeed = picto.bonusSpeed;
-        entity.bonusCritChance = picto.bonusCritChance;
-        entity.bonusHealth = picto.bonusHealth;
-        entity.luminaCost = picto.luminaCost;
         entity.details.clear();
-        if (picto.details != null) {
-            picto.details.forEach(d -> d.idPicto = id);
-            entity.details.addAll(picto.details);
+        if (damageBuffType.details != null) {
+            damageBuffType.details.forEach(d -> d.idDamageBuffType = damageBuffType.idDamageBuffType);
+            entity.details.addAll(damageBuffType.details);
         }
         return Response.ok(entity).build();
     }
@@ -52,7 +45,7 @@ public class AdminPictoResource {
     @Path("{id}")
     @RolesAllowed("coh-app:admin")
     @Transactional
-    public Response delete(@PathParam("id") String id) {
+    public Response delete(@PathParam("id") Integer id) {
         boolean deleted = repository.deleteById(id);
         if (!deleted) {
             return Response.status(Response.Status.NOT_FOUND).build();

--- a/src/main/java/com/opyruso/coh/resource/AdminDamageTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminDamageTypeResource.java
@@ -1,7 +1,7 @@
 package com.opyruso.coh.resource;
 
-import com.opyruso.coh.entity.Picto;
-import com.opyruso.coh.repository.PictoRepository;
+import com.opyruso.coh.entity.DamageType;
+import com.opyruso.coh.repository.DamageTypeRepository;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -9,41 +9,34 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-@Path("/admin/pictos")
+@Path("/admin/damageTypes")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public class AdminPictoResource {
+public class AdminDamageTypeResource {
 
     @Inject
-    PictoRepository repository;
+    DamageTypeRepository repository;
 
     @POST
     @RolesAllowed("coh-app:admin")
     @Transactional
-    public Response create(Picto picto) {
-        repository.persist(picto);
-        return Response.status(Response.Status.CREATED).entity(picto).build();
+    public Response create(DamageType damageType) {
+        repository.persist(damageType);
+        return Response.status(Response.Status.CREATED).entity(damageType).build();
     }
 
     @PUT
     @RolesAllowed("coh-app:admin")
     @Transactional
-    public Response update(Picto picto) {
-        String id = picto.idPicto;
-        Picto entity = repository.findById(id);
+    public Response update(DamageType damageType) {
+        DamageType entity = repository.findById(damageType.idDamageType);
         if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        entity.level = picto.level;
-        entity.bonusDefense = picto.bonusDefense;
-        entity.bonusSpeed = picto.bonusSpeed;
-        entity.bonusCritChance = picto.bonusCritChance;
-        entity.bonusHealth = picto.bonusHealth;
-        entity.luminaCost = picto.luminaCost;
         entity.details.clear();
-        if (picto.details != null) {
-            picto.details.forEach(d -> d.idPicto = id);
-            entity.details.addAll(picto.details);
+        if (damageType.details != null) {
+            damageType.details.forEach(d -> d.idDamageType = damageType.idDamageType);
+            entity.details.addAll(damageType.details);
         }
         return Response.ok(entity).build();
     }
@@ -52,7 +45,7 @@ public class AdminPictoResource {
     @Path("{id}")
     @RolesAllowed("coh-app:admin")
     @Transactional
-    public Response delete(@PathParam("id") String id) {
+    public Response delete(@PathParam("id") Integer id) {
         boolean deleted = repository.deleteById(id);
         if (!deleted) {
             return Response.status(Response.Status.NOT_FOUND).build();

--- a/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
@@ -26,10 +26,10 @@ public class AdminWeaponResource {
     }
 
     @PUT
-    @Path("{id}")
     @RolesAllowed("coh-app:admin")
     @Transactional
-    public Response update(@PathParam("id") String id, Weapon weapon) {
+    public Response update(Weapon weapon) {
+        String id = weapon.idWeapon;
         Weapon entity = repository.findById(id);
         if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();


### PR DESCRIPTION
## Summary
- enable management of characters, damage types, damage buff types
- adjust picto and weapon update APIs to use body ID
- provide simple panache repositories for new entities

## Testing
- `mvn package -DskipTests` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687dbb930f84832cb8623c72c25db4b1