### PR TITLE
Update admin resource paths

### DIFF
--- a/src/main/java/com/opyruso/coh/resource/AdminCharacterResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCharacterResource.java
@@ -18,7 +18,7 @@ public class AdminCharacterResource {
     CharacterRepository repository;
 
     @POST
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response create(Character character) {
         repository.persist(character);
@@ -26,7 +26,7 @@ public class AdminCharacterResource {
     }
 
     @PUT
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response update(Character character) {
         Character entity = repository.findById(character.idCharacter);
@@ -43,7 +43,7 @@ public class AdminCharacterResource {
 
     @DELETE
     @Path("{id}")
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response delete(@PathParam("id") String id) {
         boolean deleted = repository.deleteById(id);

--- a/src/main/java/com/opyruso/coh/resource/AdminDamageBuffTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminDamageBuffTypeResource.java
@@ -9,7 +9,7 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-@Path("/admin/damageBuffTypes")
+@Path("/admin/damagebufftypes")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class AdminDamageBuffTypeResource {
@@ -18,7 +18,7 @@ public class AdminDamageBuffTypeResource {
     DamageBuffTypeRepository repository;
 
     @POST
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response create(DamageBuffType damageBuffType) {
         repository.persist(damageBuffType);
@@ -26,7 +26,7 @@ public class AdminDamageBuffTypeResource {
     }
 
     @PUT
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response update(DamageBuffType damageBuffType) {
         DamageBuffType entity = repository.findById(damageBuffType.idDamageBuffType);
@@ -43,7 +43,7 @@ public class AdminDamageBuffTypeResource {
 
     @DELETE
     @Path("{id}")
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response delete(@PathParam("id") Integer id) {
         boolean deleted = repository.deleteById(id);

--- a/src/main/java/com/opyruso/coh/resource/AdminDamageTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminDamageTypeResource.java
@@ -9,7 +9,7 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-@Path("/admin/damageTypes")
+@Path("/admin/damagetypes")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class AdminDamageTypeResource {
@@ -18,7 +18,7 @@ public class AdminDamageTypeResource {
     DamageTypeRepository repository;
 
     @POST
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response create(DamageType damageType) {
         repository.persist(damageType);
@@ -26,7 +26,7 @@ public class AdminDamageTypeResource {
     }
 
     @PUT
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response update(DamageType damageType) {
         DamageType entity = repository.findById(damageType.idDamageType);
@@ -43,7 +43,7 @@ public class AdminDamageTypeResource {
 
     @DELETE
     @Path("{id}")
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response delete(@PathParam("id") Integer id) {
         boolean deleted = repository.deleteById(id);

--- a/src/main/java/com/opyruso/coh/resource/AdminPictoResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminPictoResource.java
@@ -18,7 +18,7 @@ public class AdminPictoResource {
     PictoRepository repository;
 
     @POST
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response create(Picto picto) {
         repository.persist(picto);
@@ -26,7 +26,7 @@ public class AdminPictoResource {
     }
 
     @PUT
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response update(Picto picto) {
         String id = picto.idPicto;
@@ -50,7 +50,7 @@ public class AdminPictoResource {
 
     @DELETE
     @Path("{id}")
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response delete(@PathParam("id") String id) {
         boolean deleted = repository.deleteById(id);

--- a/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
@@ -18,7 +18,7 @@ public class AdminWeaponResource {
     WeaponRepository repository;
 
     @POST
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response create(Weapon weapon) {
         repository.persist(weapon);
@@ -26,7 +26,7 @@ public class AdminWeaponResource {
     }
 
     @PUT
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response update(Weapon weapon) {
         String id = weapon.idWeapon;
@@ -48,7 +48,7 @@ public class AdminWeaponResource {
 
     @DELETE
     @Path("{id}")
-    @RolesAllowed("coh-app:admin")
+    @RolesAllowed("admin")
     @Transactional
     public Response delete(@PathParam("id") String id) {
         boolean deleted = repository.deleteById(id);


### PR DESCRIPTION
## Summary
- normalize paths for admin damage type resources (lowercase)
- keep admin-only access using plain `admin` role

## Testing
- `mvn -q test` *(fails: `mvn` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e1be3f008832c9d0547deb2701c4f