### PR TITLE
Add admin endpoints for object details

### DIFF
--- a/src/main/java/com/opyruso/coh/model/dto/CharacterWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/CharacterWithDetails.java
@@ -1,0 +1,8 @@
+package com.opyruso.coh.model.dto;
+
+public class CharacterWithDetails {
+    public String idCharacter;
+    public String lang;
+    public String name;
+    public String story;
+}

--- a/src/main/java/com/opyruso/coh/model/dto/DamageBuffTypeWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/DamageBuffTypeWithDetails.java
@@ -1,0 +1,7 @@
+package com.opyruso.coh.model.dto;
+
+public class DamageBuffTypeWithDetails {
+    public Integer idDamageBuffType;
+    public String lang;
+    public String name;
+}

--- a/src/main/java/com/opyruso/coh/model/dto/DamageTypeWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/DamageTypeWithDetails.java
@@ -1,0 +1,7 @@
+package com.opyruso.coh.model.dto;
+
+public class DamageTypeWithDetails {
+    public Integer idDamageType;
+    public String lang;
+    public String name;
+}

--- a/src/main/java/com/opyruso/coh/model/dto/PictoWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/PictoWithDetails.java
@@ -1,0 +1,16 @@
+package com.opyruso.coh.model.dto;
+
+public class PictoWithDetails {
+    public String idPicto;
+    public int level;
+    public int bonusDefense;
+    public int bonusSpeed;
+    public int bonusCritChance;
+    public int bonusHealth;
+    public int luminaCost;
+    public String lang;
+    public String name;
+    public String region;
+    public String descrptionBonusLumina;
+    public String unlockDescription;
+}

--- a/src/main/java/com/opyruso/coh/model/dto/WeaponWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/WeaponWithDetails.java
@@ -1,0 +1,16 @@
+package com.opyruso.coh.model.dto;
+
+public class WeaponWithDetails {
+    public String idWeapon;
+    public String character;
+    public Integer damageType;
+    public Integer damageBuffType1;
+    public Integer damageBuffType2;
+    public String lang;
+    public String name;
+    public String region;
+    public String unlockDescription;
+    public String weaponEffect1;
+    public String weaponEffect2;
+    public String weaponEffect3;
+}

--- a/src/main/java/com/opyruso/coh/resource/AdminCharacterResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCharacterResource.java
@@ -1,7 +1,9 @@
 package com.opyruso.coh.resource;
 
 import com.opyruso.coh.entity.Character;
+import com.opyruso.coh.entity.CharacterDetails;
 import com.opyruso.coh.repository.CharacterRepository;
+import com.opyruso.coh.model.dto.CharacterWithDetails;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -20,24 +22,50 @@ public class AdminCharacterResource {
     @POST
     @RolesAllowed("admin")
     @Transactional
-    public Response create(Character character) {
+    public Response create(CharacterWithDetails payload) {
+        Character character = new Character();
+        character.idCharacter = payload.idCharacter;
+
+        CharacterDetails details = new CharacterDetails();
+        details.idCharacter = payload.idCharacter;
+        details.lang = payload.lang;
+        details.name = payload.name;
+        details.story = payload.story;
+        details.character = character;
+
+        character.details = new java.util.ArrayList<>(java.util.List.of(details));
+
         repository.persist(character);
         return Response.status(Response.Status.CREATED).entity(character).build();
     }
 
     @PUT
+    @Path("{id}")
     @RolesAllowed("admin")
     @Transactional
-    public Response update(Character character) {
-        Character entity = repository.findById(character.idCharacter);
+    public Response update(@PathParam("id") String id, CharacterWithDetails payload) {
+        Character entity = repository.findById(id);
         if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        entity.details.clear();
-        if (character.details != null) {
-            character.details.forEach(d -> d.idCharacter = character.idCharacter);
-            entity.details.addAll(character.details);
+        if (entity.details == null) {
+            entity.details = new java.util.ArrayList<>();
         }
+        CharacterDetails details = entity.details.stream()
+                .filter(d -> d.lang.equals(payload.lang))
+                .findFirst()
+                .orElseGet(() -> {
+                    CharacterDetails d = new CharacterDetails();
+                    d.idCharacter = id;
+                    d.lang = payload.lang;
+                    d.character = entity;
+                    entity.details.add(d);
+                    return d;
+                });
+
+        details.name = payload.name;
+        details.story = payload.story;
+
         return Response.ok(entity).build();
     }
 

--- a/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
@@ -1,7 +1,8 @@
 package com.opyruso.coh.resource;
 
-import com.opyruso.coh.entity.Weapon;
-import com.opyruso.coh.repository.WeaponRepository;
+import com.opyruso.coh.entity.*;
+import com.opyruso.coh.repository.*;
+import com.opyruso.coh.model.dto.WeaponWithDetails;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -16,33 +17,77 @@ public class AdminWeaponResource {
 
     @Inject
     WeaponRepository repository;
+    @Inject
+    CharacterRepository characterRepository;
+    @Inject
+    DamageTypeRepository damageTypeRepository;
+    @Inject
+    DamageBuffTypeRepository damageBuffTypeRepository;
 
     @POST
     @RolesAllowed("admin")
     @Transactional
-    public Response create(Weapon weapon) {
+    public Response create(WeaponWithDetails payload) {
+        Weapon weapon = new Weapon();
+        weapon.idWeapon = payload.idWeapon;
+        weapon.character = characterRepository.findById(payload.character);
+        weapon.damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
+        weapon.damageBuffType1 = payload.damageBuffType1 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType1);
+        weapon.damageBuffType2 = payload.damageBuffType2 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType2);
+
+        WeaponDetails details = new WeaponDetails();
+        details.idWeapon = payload.idWeapon;
+        details.lang = payload.lang;
+        details.name = payload.name;
+        details.region = payload.region;
+        details.unlockDescription = payload.unlockDescription;
+        details.weaponEffect1 = payload.weaponEffect1;
+        details.weaponEffect2 = payload.weaponEffect2;
+        details.weaponEffect3 = payload.weaponEffect3;
+        details.weapon = weapon;
+
+        weapon.details = new java.util.ArrayList<>(java.util.List.of(details));
+
         repository.persist(weapon);
         return Response.status(Response.Status.CREATED).entity(weapon).build();
     }
 
     @PUT
+    @Path("{id}")
     @RolesAllowed("admin")
     @Transactional
-    public Response update(Weapon weapon) {
-        String id = weapon.idWeapon;
+    public Response update(@PathParam("id") String id, WeaponWithDetails payload) {
         Weapon entity = repository.findById(id);
         if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        entity.character = weapon.character;
-        entity.damageType = weapon.damageType;
-        entity.damageBuffType1 = weapon.damageBuffType1;
-        entity.damageBuffType2 = weapon.damageBuffType2;
-        entity.details.clear();
-        if (weapon.details != null) {
-            weapon.details.forEach(d -> d.idWeapon = id);
-            entity.details.addAll(weapon.details);
+        entity.character = characterRepository.findById(payload.character);
+        entity.damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
+        entity.damageBuffType1 = payload.damageBuffType1 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType1);
+        entity.damageBuffType2 = payload.damageBuffType2 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType2);
+
+        if (entity.details == null) {
+            entity.details = new java.util.ArrayList<>();
         }
+        WeaponDetails details = entity.details.stream()
+                .filter(d -> d.lang.equals(payload.lang))
+                .findFirst()
+                .orElseGet(() -> {
+                    WeaponDetails d = new WeaponDetails();
+                    d.idWeapon = id;
+                    d.lang = payload.lang;
+                    d.weapon = entity;
+                    entity.details.add(d);
+                    return d;
+                });
+
+        details.name = payload.name;
+        details.region = payload.region;
+        details.unlockDescription = payload.unlockDescription;
+        details.weaponEffect1 = payload.weaponEffect1;
+        details.weaponEffect2 = payload.weaponEffect2;
+        details.weaponEffect3 = payload.weaponEffect3;
+
         return Response.ok(entity).build();
     }
 


### PR DESCRIPTION
## Summary
- implement DTOs for all entities with translation details
- adapt admin resources to support POST/PUT using flattened payloads

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e9f623018832c8562a595a20e5a5b