### PR TITLE
Add capacity entities and admin endpoints

### DIFF
--- a/src/main/java/com/opyruso/coh/entity/Capacity.java
+++ b/src/main/java/com/opyruso/coh/entity/Capacity.java
@@ -1,0 +1,44 @@
+package com.opyruso.coh.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "capacity")
+public class Capacity extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "id_capacity")
+    public Integer idCapacity;
+
+    @ManyToOne
+    @JoinColumn(name = "id_character")
+    public Character character;
+
+    @Column(name = "energy_cost")
+    public Integer energyCost;
+
+    @Column(name = "can_break")
+    public Integer canBreak;
+
+    @ManyToOne
+    @JoinColumn(name = "damage_type")
+    public DamageType damageType;
+
+    @ManyToOne
+    @JoinColumn(name = "type")
+    public CapacityType type;
+
+    @Column(name = "is_multi_target")
+    public Integer isMultiTarget;
+
+    @Column(name = "grid_position_x")
+    public Integer gridPositionX;
+
+    @Column(name = "grid_position_y")
+    public Integer gridPositionY;
+
+    @OneToMany(mappedBy = "capacity", cascade = CascadeType.ALL, orphanRemoval = true)
+    public List<CapacityDetails> details;
+}

--- a/src/main/java/com/opyruso/coh/entity/CapacityDetails.java
+++ b/src/main/java/com/opyruso/coh/entity/CapacityDetails.java
@@ -1,0 +1,58 @@
+package com.opyruso.coh.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "capacity_details")
+@IdClass(CapacityDetails.PK.class)
+public class CapacityDetails extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "id_capacity")
+    public Integer idCapacity;
+
+    @Id
+    @Column(name = "lang")
+    public String lang;
+
+    @Column(name = "name")
+    public String name;
+
+    @Column(name = "effect_primary")
+    public String effectPrimary;
+
+    @Column(name = "effect_secondary")
+    public String effectSecondary;
+
+    @Column(name = "bonus_description")
+    public String bonusDescription;
+
+    @Column(name = "additionnal_description")
+    public String additionnalDescription;
+
+    @ManyToOne
+    @JoinColumn(name = "id_capacity", insertable = false, updatable = false)
+    @JsonIgnore
+    public Capacity capacity;
+
+    public static class PK implements Serializable {
+        public Integer idCapacity;
+        public String lang;
+
+        @Override
+        public int hashCode() {
+            return (idCapacity + "#" + lang).hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            PK other = (PK) obj;
+            return idCapacity.equals(other.idCapacity) && lang.equals(other.lang);
+        }
+    }
+}

--- a/src/main/java/com/opyruso/coh/entity/CapacityType.java
+++ b/src/main/java/com/opyruso/coh/entity/CapacityType.java
@@ -1,0 +1,17 @@
+package com.opyruso.coh.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "capacity_type")
+public class CapacityType extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "id_capacity_type")
+    public Integer idCapacityType;
+
+    @OneToMany(mappedBy = "capacityType", cascade = CascadeType.ALL, orphanRemoval = true)
+    public List<CapacityTypeDetails> details;
+}

--- a/src/main/java/com/opyruso/coh/entity/CapacityTypeDetails.java
+++ b/src/main/java/com/opyruso/coh/entity/CapacityTypeDetails.java
@@ -1,0 +1,46 @@
+package com.opyruso.coh.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "capacity_type_details")
+@IdClass(CapacityTypeDetails.PK.class)
+public class CapacityTypeDetails extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "id_capacity_type")
+    public Integer idCapacityType;
+
+    @Id
+    @Column(name = "lang")
+    public String lang;
+
+    @Column(name = "name")
+    public String name;
+
+    @ManyToOne
+    @JoinColumn(name = "id_capacity_type", insertable = false, updatable = false)
+    @JsonIgnore
+    public CapacityType capacityType;
+
+    public static class PK implements Serializable {
+        public Integer idCapacityType;
+        public String lang;
+
+        @Override
+        public int hashCode() {
+            return (idCapacityType + "#" + lang).hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            PK other = (PK) obj;
+            return idCapacityType.equals(other.idCapacityType) && lang.equals(other.lang);
+        }
+    }
+}

--- a/src/main/java/com/opyruso/coh/model/dto/CapacityTypeWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/CapacityTypeWithDetails.java
@@ -1,0 +1,7 @@
+package com.opyruso.coh.model.dto;
+
+public class CapacityTypeWithDetails {
+    public Integer idCapacityType;
+    public String lang;
+    public String name;
+}

--- a/src/main/java/com/opyruso/coh/model/dto/CapacityWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/CapacityWithDetails.java
@@ -1,0 +1,19 @@
+package com.opyruso.coh.model.dto;
+
+public class CapacityWithDetails {
+    public Integer idCapacity;
+    public String character;
+    public Integer energyCost;
+    public Integer canBreak;
+    public Integer damageType;
+    public Integer type;
+    public Integer isMultiTarget;
+    public Integer gridPositionX;
+    public Integer gridPositionY;
+    public String lang;
+    public String name;
+    public String effectPrimary;
+    public String effectSecondary;
+    public String bonusDescription;
+    public String additionnalDescription;
+}

--- a/src/main/java/com/opyruso/coh/repository/CapacityRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/CapacityRepository.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.repository;
+
+import com.opyruso.coh.entity.Capacity;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CapacityRepository implements PanacheRepositoryBase<Capacity, Integer> {
+}

--- a/src/main/java/com/opyruso/coh/repository/CapacityTypeRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/CapacityTypeRepository.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.repository;
+
+import com.opyruso.coh.entity.CapacityType;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CapacityTypeRepository implements PanacheRepositoryBase<CapacityType, Integer> {
+}

--- a/src/main/java/com/opyruso/coh/resource/AdminCapacityResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCapacityResource.java
@@ -1,0 +1,111 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.*;
+import com.opyruso.coh.repository.*;
+import com.opyruso.coh.model.dto.CapacityWithDetails;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/admin/capacities")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class AdminCapacityResource {
+
+    @Inject
+    CapacityRepository repository;
+    @Inject
+    CharacterRepository characterRepository;
+    @Inject
+    DamageTypeRepository damageTypeRepository;
+    @Inject
+    CapacityTypeRepository capacityTypeRepository;
+
+    @POST
+    @RolesAllowed("admin")
+    @Transactional
+    public Response create(CapacityWithDetails payload) {
+        Capacity capacity = new Capacity();
+        capacity.idCapacity = payload.idCapacity;
+        capacity.character = characterRepository.findById(payload.character);
+        capacity.energyCost = payload.energyCost;
+        capacity.canBreak = payload.canBreak;
+        capacity.damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
+        capacity.type = payload.type == null ? null : capacityTypeRepository.findById(payload.type);
+        capacity.isMultiTarget = payload.isMultiTarget;
+        capacity.gridPositionX = payload.gridPositionX;
+        capacity.gridPositionY = payload.gridPositionY;
+
+        CapacityDetails details = new CapacityDetails();
+        details.idCapacity = payload.idCapacity;
+        details.lang = payload.lang;
+        details.name = payload.name;
+        details.effectPrimary = payload.effectPrimary;
+        details.effectSecondary = payload.effectSecondary;
+        details.bonusDescription = payload.bonusDescription;
+        details.additionnalDescription = payload.additionnalDescription;
+        details.capacity = capacity;
+
+        capacity.details = new java.util.ArrayList<>(java.util.List.of(details));
+
+        repository.persist(capacity);
+        return Response.status(Response.Status.CREATED).entity(capacity).build();
+    }
+
+    @PUT
+    @Path("{id}")
+    @RolesAllowed("admin")
+    @Transactional
+    public Response update(@PathParam("id") Integer id, CapacityWithDetails payload) {
+        Capacity entity = repository.findById(id);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        entity.character = characterRepository.findById(payload.character);
+        entity.energyCost = payload.energyCost;
+        entity.canBreak = payload.canBreak;
+        entity.damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
+        entity.type = payload.type == null ? null : capacityTypeRepository.findById(payload.type);
+        entity.isMultiTarget = payload.isMultiTarget;
+        entity.gridPositionX = payload.gridPositionX;
+        entity.gridPositionY = payload.gridPositionY;
+
+        if (entity.details == null) {
+            entity.details = new java.util.ArrayList<>();
+        }
+        CapacityDetails details = entity.details.stream()
+                .filter(d -> d.lang.equals(payload.lang))
+                .findFirst()
+                .orElseGet(() -> {
+                    CapacityDetails d = new CapacityDetails();
+                    d.idCapacity = id;
+                    d.lang = payload.lang;
+                    d.capacity = entity;
+                    entity.details.add(d);
+                    return d;
+                });
+
+        details.name = payload.name;
+        details.effectPrimary = payload.effectPrimary;
+        details.effectSecondary = payload.effectSecondary;
+        details.bonusDescription = payload.bonusDescription;
+        details.additionnalDescription = payload.additionnalDescription;
+
+        return Response.ok(entity).build();
+    }
+
+    @DELETE
+    @Path("{id}")
+    @RolesAllowed("admin")
+    @Transactional
+    public Response delete(@PathParam("id") Integer id) {
+        boolean deleted = repository.deleteById(id);
+        if (!deleted) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.noContent().build();
+    }
+}

--- a/src/main/java/com/opyruso/coh/resource/AdminCapacityTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCapacityTypeResource.java
@@ -1,0 +1,81 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.CapacityType;
+import com.opyruso.coh.entity.CapacityTypeDetails;
+import com.opyruso.coh.repository.CapacityTypeRepository;
+import com.opyruso.coh.model.dto.CapacityTypeWithDetails;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/admin/capacitytypes")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class AdminCapacityTypeResource {
+
+    @Inject
+    CapacityTypeRepository repository;
+
+    @POST
+    @RolesAllowed("admin")
+    @Transactional
+    public Response create(CapacityTypeWithDetails payload) {
+        CapacityType type = new CapacityType();
+        type.idCapacityType = payload.idCapacityType;
+
+        CapacityTypeDetails details = new CapacityTypeDetails();
+        details.idCapacityType = payload.idCapacityType;
+        details.lang = payload.lang;
+        details.name = payload.name;
+        details.capacityType = type;
+
+        type.details = new java.util.ArrayList<>(java.util.List.of(details));
+
+        repository.persist(type);
+        return Response.status(Response.Status.CREATED).entity(type).build();
+    }
+
+    @PUT
+    @Path("{id}")
+    @RolesAllowed("admin")
+    @Transactional
+    public Response update(@PathParam("id") Integer id, CapacityTypeWithDetails payload) {
+        CapacityType entity = repository.findById(id);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (entity.details == null) {
+            entity.details = new java.util.ArrayList<>();
+        }
+        CapacityTypeDetails details = entity.details.stream()
+                .filter(d -> d.lang.equals(payload.lang))
+                .findFirst()
+                .orElseGet(() -> {
+                    CapacityTypeDetails d = new CapacityTypeDetails();
+                    d.idCapacityType = id;
+                    d.lang = payload.lang;
+                    d.capacityType = entity;
+                    entity.details.add(d);
+                    return d;
+                });
+
+        details.name = payload.name;
+
+        return Response.ok(entity).build();
+    }
+
+    @DELETE
+    @Path("{id}")
+    @RolesAllowed("admin")
+    @Transactional
+    public Response delete(@PathParam("id") Integer id) {
+        boolean deleted = repository.deleteById(id);
+        if (!deleted) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.noContent().build();
+    }
+}


### PR DESCRIPTION
## Summary
- add capacity type and capacity entities with detail tables
- introduce DTOs for capacity and capacity type create/update
- add repositories
- implement admin resources for capacity and capacity types

## Testing
- `mvn -q test` *(fails: dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68806147c680832ca35fb037308e37a2