### PR TITLE
Add outfit entity and admin endpoints

### DIFF
--- a/src/main/java/com/opyruso/coh/entity/Outfit.java
+++ b/src/main/java/com/opyruso/coh/entity/Outfit.java
@@ -1,0 +1,21 @@
+package com.opyruso.coh.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "outfit")
+public class Outfit extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "id_outfit")
+    public String idOutfit;
+
+    @ManyToOne
+    @JoinColumn(name = "id_character")
+    public Character character;
+
+    @OneToMany(mappedBy = "outfit", cascade = CascadeType.ALL, orphanRemoval = true)
+    public List<OutfitDetails> details;
+}

--- a/src/main/java/com/opyruso/coh/entity/OutfitDetails.java
+++ b/src/main/java/com/opyruso/coh/entity/OutfitDetails.java
@@ -1,0 +1,49 @@
+package com.opyruso.coh.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "outfit_details")
+@IdClass(OutfitDetails.PK.class)
+public class OutfitDetails extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "id_outfit")
+    public String idOutfit;
+
+    @Id
+    @Column(name = "lang")
+    public String lang;
+
+    @Column(name = "name")
+    public String name;
+
+    @Column(name = "description")
+    public String description;
+
+    @ManyToOne
+    @JoinColumn(name = "id_outfit", insertable = false, updatable = false)
+    @JsonIgnore
+    public Outfit outfit;
+
+    public static class PK implements Serializable {
+        public String idOutfit;
+        public String lang;
+
+        @Override
+        public int hashCode() {
+            return (idOutfit + "#" + lang).hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            PK other = (PK) obj;
+            return idOutfit.equals(other.idOutfit) && lang.equals(other.lang);
+        }
+    }
+}

--- a/src/main/java/com/opyruso/coh/model/PublicData.java
+++ b/src/main/java/com/opyruso/coh/model/PublicData.java
@@ -9,6 +9,7 @@ import com.opyruso.coh.entity.Picto;
 import com.opyruso.coh.entity.Weapon;
 import com.opyruso.coh.entity.Capacity;
 import com.opyruso.coh.entity.CapacityType;
+import com.opyruso.coh.entity.Outfit;
 
 public class PublicData {
     public List<Character> characters;
@@ -18,4 +19,5 @@ public class PublicData {
     public List<Weapon> weapons;
     public List<Capacity> capacities;
     public List<CapacityType> capacityTypes;
+    public List<Outfit> outfits;
 }

--- a/src/main/java/com/opyruso/coh/model/dto/OutfitWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/OutfitWithDetails.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.model.dto;
+
+public class OutfitWithDetails {
+    public String idOutfit;
+    public String character;
+    public String lang;
+    public String name;
+    public String description;
+}

--- a/src/main/java/com/opyruso/coh/repository/OutfitRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/OutfitRepository.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.repository;
+
+import com.opyruso.coh.entity.Outfit;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class OutfitRepository implements PanacheRepositoryBase<Outfit, String> {
+}

--- a/src/main/java/com/opyruso/coh/resource/AdminOutfitResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminOutfitResource.java
@@ -1,0 +1,87 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.*;
+import com.opyruso.coh.repository.*;
+import com.opyruso.coh.model.dto.OutfitWithDetails;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/admin/outfits")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class AdminOutfitResource {
+
+    @Inject
+    OutfitRepository repository;
+    @Inject
+    CharacterRepository characterRepository;
+
+    @POST
+    @RolesAllowed("admin")
+    @Transactional
+    public Response create(OutfitWithDetails payload) {
+        Outfit outfit = new Outfit();
+        outfit.idOutfit = payload.idOutfit;
+        outfit.character = characterRepository.findById(payload.character);
+
+        OutfitDetails details = new OutfitDetails();
+        details.idOutfit = payload.idOutfit;
+        details.lang = payload.lang;
+        details.name = payload.name;
+        details.description = payload.description;
+        details.outfit = outfit;
+
+        outfit.details = new java.util.ArrayList<>(java.util.List.of(details));
+
+        repository.persist(outfit);
+        return Response.status(Response.Status.CREATED).entity(outfit).build();
+    }
+
+    @PUT
+    @Path("{id}")
+    @RolesAllowed("admin")
+    @Transactional
+    public Response update(@PathParam("id") String id, OutfitWithDetails payload) {
+        Outfit entity = repository.findById(id);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        entity.character = characterRepository.findById(payload.character);
+
+        if (entity.details == null) {
+            entity.details = new java.util.ArrayList<>();
+        }
+        OutfitDetails details = entity.details.stream()
+                .filter(d -> d.lang.equals(payload.lang))
+                .findFirst()
+                .orElseGet(() -> {
+                    OutfitDetails d = new OutfitDetails();
+                    d.idOutfit = id;
+                    d.lang = payload.lang;
+                    d.outfit = entity;
+                    entity.details.add(d);
+                    return d;
+                });
+
+        details.name = payload.name;
+        details.description = payload.description;
+
+        return Response.ok(entity).build();
+    }
+
+    @DELETE
+    @Path("{id}")
+    @RolesAllowed("admin")
+    @Transactional
+    public Response delete(@PathParam("id") String id) {
+        boolean deleted = repository.deleteById(id);
+        if (!deleted) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.noContent().build();
+    }
+}

--- a/src/main/java/com/opyruso/coh/resource/PublicDataResource.java
+++ b/src/main/java/com/opyruso/coh/resource/PublicDataResource.java
@@ -7,6 +7,7 @@ import com.opyruso.coh.entity.Picto;
 import com.opyruso.coh.entity.Weapon;
 import com.opyruso.coh.entity.Capacity;
 import com.opyruso.coh.entity.CapacityType;
+import com.opyruso.coh.entity.Outfit;
 import com.opyruso.coh.model.PublicData;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -67,6 +68,11 @@ public class PublicDataResource {
                 .find(
                         "select distinct ct from CapacityType ct " +
                                 "left join fetch ct.details d")
+                .list();
+        data.outfits = Outfit
+                .find(
+                        "select distinct o from Outfit o " +
+                                "left join fetch o.details d")
                 .list();
 
         em.clear();
@@ -142,6 +148,20 @@ public class PublicDataResource {
                 wd.weaponEffect2 = "";
                 wd.weaponEffect3 = "";
                 w.details = new java.util.ArrayList<>(java.util.List.of(wd));
+            }
+        });
+
+        data.outfits.forEach(o -> {
+            if (o.details != null) {
+                o.details.removeIf(d -> !lang.equals(d.lang));
+            }
+            if (o.details == null || o.details.isEmpty()) {
+                var od = new com.opyruso.coh.entity.OutfitDetails();
+                od.idOutfit = o.idOutfit;
+                od.lang = lang;
+                od.name = "";
+                od.description = "";
+                o.details = new java.util.ArrayList<>(java.util.List.of(od));
             }
         });
 


### PR DESCRIPTION
## Summary
- add Outfit and OutfitDetails entities
- expose admin endpoints for outfits
- store outfits in repository layer
- include outfits in the public data model and resource

## Testing
- `mvn -q -DskipTests package` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68831a74af0c832cba145f84d7ebf433