### PR TITLE
Add validation for admin capacities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,22 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-oidc</artifactId>
     </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-security</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/opyruso/coh/resource/AdminCapacityResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCapacityResource.java
@@ -28,13 +28,26 @@ public class AdminCapacityResource {
     @RolesAllowed("admin")
     @Transactional
     public Response create(CapacityWithDetails payload) {
+        Character character = characterRepository.findById(payload.character);
+        if (character == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid character").build();
+        }
+        DamageType damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
+        if (payload.damageType != null && damageType == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage type").build();
+        }
+        CapacityType type = payload.type == null ? null : capacityTypeRepository.findById(payload.type);
+        if (payload.type != null && type == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid capacity type").build();
+        }
+
         Capacity capacity = new Capacity();
         capacity.idCapacity = payload.idCapacity;
-        capacity.character = characterRepository.findById(payload.character);
+        capacity.character = character;
         capacity.energyCost = payload.energyCost;
         capacity.canBreak = payload.canBreak;
-        capacity.damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
-        capacity.type = payload.type == null ? null : capacityTypeRepository.findById(payload.type);
+        capacity.damageType = damageType;
+        capacity.type = type;
         capacity.isMultiTarget = payload.isMultiTarget;
         capacity.gridPositionX = payload.gridPositionX;
         capacity.gridPositionY = payload.gridPositionY;
@@ -64,11 +77,25 @@ public class AdminCapacityResource {
         if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        entity.character = characterRepository.findById(payload.character);
+
+        Character character = characterRepository.findById(payload.character);
+        if (character == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid character").build();
+        }
+        DamageType damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
+        if (payload.damageType != null && damageType == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage type").build();
+        }
+        CapacityType type = payload.type == null ? null : capacityTypeRepository.findById(payload.type);
+        if (payload.type != null && type == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid capacity type").build();
+        }
+
+        entity.character = character;
         entity.energyCost = payload.energyCost;
         entity.canBreak = payload.canBreak;
-        entity.damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
-        entity.type = payload.type == null ? null : capacityTypeRepository.findById(payload.type);
+        entity.damageType = damageType;
+        entity.type = type;
         entity.isMultiTarget = payload.isMultiTarget;
         entity.gridPositionX = payload.gridPositionX;
         entity.gridPositionY = payload.gridPositionY;

--- a/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
@@ -28,12 +28,29 @@ public class AdminWeaponResource {
     @RolesAllowed("admin")
     @Transactional
     public Response create(WeaponWithDetails payload) {
+        Character character = characterRepository.findById(payload.character);
+        if (character == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid character").build();
+        }
+        DamageType damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
+        if (payload.damageType != null && damageType == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage type").build();
+        }
+        DamageBuffType damageBuffType1 = payload.damageBuffType1 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType1);
+        if (payload.damageBuffType1 != null && damageBuffType1 == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage buff type 1").build();
+        }
+        DamageBuffType damageBuffType2 = payload.damageBuffType2 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType2);
+        if (payload.damageBuffType2 != null && damageBuffType2 == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage buff type 2").build();
+        }
+
         Weapon weapon = new Weapon();
         weapon.idWeapon = payload.idWeapon;
-        weapon.character = characterRepository.findById(payload.character);
-        weapon.damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
-        weapon.damageBuffType1 = payload.damageBuffType1 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType1);
-        weapon.damageBuffType2 = payload.damageBuffType2 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType2);
+        weapon.character = character;
+        weapon.damageType = damageType;
+        weapon.damageBuffType1 = damageBuffType1;
+        weapon.damageBuffType2 = damageBuffType2;
 
         WeaponDetails details = new WeaponDetails();
         details.idWeapon = payload.idWeapon;
@@ -61,10 +78,28 @@ public class AdminWeaponResource {
         if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        entity.character = characterRepository.findById(payload.character);
-        entity.damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
-        entity.damageBuffType1 = payload.damageBuffType1 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType1);
-        entity.damageBuffType2 = payload.damageBuffType2 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType2);
+
+        Character character = characterRepository.findById(payload.character);
+        if (character == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid character").build();
+        }
+        DamageType damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
+        if (payload.damageType != null && damageType == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage type").build();
+        }
+        DamageBuffType damageBuffType1 = payload.damageBuffType1 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType1);
+        if (payload.damageBuffType1 != null && damageBuffType1 == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage buff type 1").build();
+        }
+        DamageBuffType damageBuffType2 = payload.damageBuffType2 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType2);
+        if (payload.damageBuffType2 != null && damageBuffType2 == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage buff type 2").build();
+        }
+
+        entity.character = character;
+        entity.damageType = damageType;
+        entity.damageBuffType1 = damageBuffType1;
+        entity.damageBuffType2 = damageBuffType2;
 
         if (entity.details == null) {
             entity.details = new java.util.ArrayList<>();

--- a/src/test/java/com/opyruso/coh/resource/AdminCapacityResourceTest.java
+++ b/src/test/java/com/opyruso/coh/resource/AdminCapacityResourceTest.java
@@ -1,0 +1,100 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.*;
+import com.opyruso.coh.model.dto.CapacityWithDetails;
+import com.opyruso.coh.repository.*;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class AdminCapacityResourceTest {
+
+    @Inject
+    CapacityRepository capacityRepository;
+    @Inject
+    CharacterRepository characterRepository;
+    @Inject
+    DamageTypeRepository damageTypeRepository;
+    @Inject
+    CapacityTypeRepository capacityTypeRepository;
+
+    @BeforeEach
+    void setUp() {
+        capacityRepository.deleteAll();
+        capacityTypeRepository.deleteAll();
+        damageTypeRepository.deleteAll();
+        characterRepository.deleteAll();
+
+        Character c = new Character();
+        c.idCharacter = "c1";
+        characterRepository.persist(c);
+
+        DamageType dt = new DamageType();
+        dt.idDamageType = "dt1";
+        damageTypeRepository.persist(dt);
+
+        CapacityType ct = new CapacityType();
+        ct.idCapacityType = "ct1";
+        capacityTypeRepository.persist(ct);
+
+        Capacity capacity = new Capacity();
+        capacity.idCapacity = "cap1";
+        capacity.character = c;
+        capacity.damageType = dt;
+        capacity.type = ct;
+
+        CapacityDetails cd = new CapacityDetails();
+        cd.idCapacity = "cap1";
+        cd.lang = "en";
+        cd.name = "name";
+        cd.capacity = capacity;
+
+        capacity.details = new java.util.ArrayList<>(java.util.List.of(cd));
+        capacityRepository.persist(capacity);
+    }
+
+    @Test
+    @TestSecurity(roles = "admin")
+    public void createInvalidCharacter() {
+        CapacityWithDetails dto = new CapacityWithDetails();
+        dto.idCapacity = "cap2";
+        dto.character = "unknown";
+        dto.damageType = "dt1";
+        dto.type = "ct1";
+        dto.lang = "en";
+        dto.name = "name";
+
+        given()
+          .contentType("application/json")
+          .body(dto)
+          .post("/admin/capacities")
+          .then()
+          .statusCode(400)
+          .body(is("Invalid character"));
+    }
+
+    @Test
+    @TestSecurity(roles = "admin")
+    public void updateInvalidDamageType() {
+        CapacityWithDetails dto = new CapacityWithDetails();
+        dto.character = "c1";
+        dto.damageType = "bad";
+        dto.type = "ct1";
+        dto.lang = "en";
+        dto.name = "name";
+
+        given()
+          .contentType("application/json")
+          .body(dto)
+          .put("/admin/capacities/cap1")
+          .then()
+          .statusCode(400)
+          .body(is("Invalid damage type"));
+    }
+}

--- a/src/test/java/com/opyruso/coh/resource/AdminWeaponResourceTest.java
+++ b/src/test/java/com/opyruso/coh/resource/AdminWeaponResourceTest.java
@@ -1,0 +1,98 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.*;
+import com.opyruso.coh.model.dto.WeaponWithDetails;
+import com.opyruso.coh.repository.*;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class AdminWeaponResourceTest {
+
+    @Inject
+    WeaponRepository weaponRepository;
+    @Inject
+    CharacterRepository characterRepository;
+    @Inject
+    DamageTypeRepository damageTypeRepository;
+    @Inject
+    DamageBuffTypeRepository damageBuffTypeRepository;
+
+    @BeforeEach
+    void setUp() {
+        weaponRepository.deleteAll();
+        damageBuffTypeRepository.deleteAll();
+        damageTypeRepository.deleteAll();
+        characterRepository.deleteAll();
+
+        Character c = new Character();
+        c.idCharacter = "c1";
+        characterRepository.persist(c);
+
+        DamageType dt = new DamageType();
+        dt.idDamageType = "dt1";
+        damageTypeRepository.persist(dt);
+
+        DamageBuffType db = new DamageBuffType();
+        db.idDamageBuffType = "db1";
+        damageBuffTypeRepository.persist(db);
+
+        Weapon w = new Weapon();
+        w.idWeapon = "w1";
+        w.character = c;
+        w.damageType = dt;
+        w.damageBuffType1 = db;
+
+        WeaponDetails wd = new WeaponDetails();
+        wd.idWeapon = "w1";
+        wd.lang = "en";
+        wd.name = "name";
+        wd.weapon = w;
+
+        w.details = new java.util.ArrayList<>(java.util.List.of(wd));
+        weaponRepository.persist(w);
+    }
+
+    @Test
+    @TestSecurity(roles = "admin")
+    public void createInvalidCharacter() {
+        WeaponWithDetails dto = new WeaponWithDetails();
+        dto.idWeapon = "w2";
+        dto.character = "unknown";
+        dto.damageType = "dt1";
+        dto.lang = "en";
+        dto.name = "bad";
+
+        given()
+          .contentType("application/json")
+          .body(dto)
+          .post("/admin/weapons")
+          .then()
+          .statusCode(400)
+          .body(is("Invalid character"));
+    }
+
+    @Test
+    @TestSecurity(roles = "admin")
+    public void updateInvalidDamageType() {
+        WeaponWithDetails dto = new WeaponWithDetails();
+        dto.character = "c1";
+        dto.damageType = "wrong";
+        dto.lang = "en";
+        dto.name = "name";
+
+        given()
+          .contentType("application/json")
+          .body(dto)
+          .put("/admin/weapons/w1")
+          .then()
+          .statusCode(400)
+          .body(is("Invalid damage type"));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=MariaDB
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.oidc.enabled=false


### PR DESCRIPTION
## Summary
- validate reference ids in `AdminCapacityResource#create` and `update`
- cover invalid references with `AdminCapacityResourceTest`

## Testing
- `mvn test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68831db8c36c832c8e3c5d3ffbd8a079