### PR TITLE
Fix weapon deletion cascade

### DIFF
--- a/src/main/java/com/opyruso/coh/repository/WeaponRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/WeaponRepository.java
@@ -12,6 +12,11 @@ public class WeaponRepository implements PanacheRepositoryBase<Weapon, Weapon.PK
     }
 
     public boolean deleteByIdWeapon(String idWeapon) {
-        return delete("idWeapon", idWeapon) > 0;
+        Weapon weapon = findByIdWeapon(idWeapon);
+        if (weapon == null) {
+            return false;
+        }
+        delete(weapon);
+        return true;
     }
 }

--- a/src/test/java/com/opyruso/coh/resource/AdminWeaponResourceTest.java
+++ b/src/test/java/com/opyruso/coh/resource/AdminWeaponResourceTest.java
@@ -12,6 +12,7 @@ import io.quarkus.test.security.TestSecurity;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
@@ -27,6 +28,8 @@ public class AdminWeaponResourceTest {
     DamageTypeRepository damageTypeRepository;
     @Inject
     DamageBuffTypeRepository damageBuffTypeRepository;
+    @Inject
+    WeaponDetailsRepository weaponDetailsRepository;
 
     @BeforeEach
     void setUp() {
@@ -100,5 +103,17 @@ public class AdminWeaponResourceTest {
           .then()
           .statusCode(400)
           .body(is("Invalid damage type"));
+    }
+
+    @Test
+    @TestSecurity(roles = "admin")
+    public void deleteWeaponRemovesDetails() {
+        given()
+          .delete("/admin/weapons/w1")
+          .then()
+          .statusCode(204);
+
+        Assertions.assertEquals(0, weaponRepository.count());
+        Assertions.assertEquals(0, weaponDetailsRepository.count());
     }
 }


### PR DESCRIPTION
## Summary
- properly remove associated weapon details when deleting a weapon
- add regression test for delete endpoint to ensure details are removed

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688390e41618832cafd09b81ebdb626f