### PR TITLE
Fix lazy loading error when serializing admin entities

### DIFF
--- a/src/main/java/com/opyruso/coh/entity/Capacity.java
+++ b/src/main/java/com/opyruso/coh/entity/Capacity.java
@@ -40,5 +40,6 @@ public class Capacity extends PanacheEntityBase {
     public Integer gridPositionY;
 
     @OneToMany(mappedBy = "capacity", cascade = CascadeType.ALL, orphanRemoval = true)
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public List<CapacityDetails> details;
 }

--- a/src/main/java/com/opyruso/coh/entity/CapacityType.java
+++ b/src/main/java/com/opyruso/coh/entity/CapacityType.java
@@ -13,5 +13,6 @@ public class CapacityType extends PanacheEntityBase {
     public String idCapacityType;
 
     @OneToMany(mappedBy = "capacityType", cascade = CascadeType.ALL, orphanRemoval = true)
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public List<CapacityTypeDetails> details;
 }

--- a/src/main/java/com/opyruso/coh/entity/Character.java
+++ b/src/main/java/com/opyruso/coh/entity/Character.java
@@ -13,5 +13,6 @@ public class Character extends PanacheEntityBase {
     public String idCharacter;
 
     @OneToMany(mappedBy = "character", cascade = CascadeType.ALL, orphanRemoval = true)
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public List<CharacterDetails> details;
 }

--- a/src/main/java/com/opyruso/coh/entity/DamageBuffType.java
+++ b/src/main/java/com/opyruso/coh/entity/DamageBuffType.java
@@ -13,5 +13,6 @@ public class DamageBuffType extends PanacheEntityBase {
     public String idDamageBuffType;
 
     @OneToMany(mappedBy = "damageBuffType", cascade = CascadeType.ALL, orphanRemoval = true)
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public List<DamageBuffTypeDetails> details;
 }

--- a/src/main/java/com/opyruso/coh/entity/DamageType.java
+++ b/src/main/java/com/opyruso/coh/entity/DamageType.java
@@ -13,5 +13,6 @@ public class DamageType extends PanacheEntityBase {
     public String idDamageType;
 
     @OneToMany(mappedBy = "damageType", cascade = CascadeType.ALL, orphanRemoval = true)
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public List<DamageTypeDetails> details;
 }

--- a/src/main/java/com/opyruso/coh/entity/Outfit.java
+++ b/src/main/java/com/opyruso/coh/entity/Outfit.java
@@ -17,5 +17,6 @@ public class Outfit extends PanacheEntityBase {
     public Character character;
 
     @OneToMany(mappedBy = "outfit", cascade = CascadeType.ALL, orphanRemoval = true)
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public List<OutfitDetails> details;
 }

--- a/src/main/java/com/opyruso/coh/entity/Picto.java
+++ b/src/main/java/com/opyruso/coh/entity/Picto.java
@@ -31,5 +31,6 @@ public class Picto extends PanacheEntityBase {
     public int luminaCost;
 
     @OneToMany(mappedBy = "picto", cascade = CascadeType.ALL, orphanRemoval = true)
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public List<PictoDetails> details;
 }

--- a/src/main/java/com/opyruso/coh/entity/Weapon.java
+++ b/src/main/java/com/opyruso/coh/entity/Weapon.java
@@ -34,6 +34,7 @@ public class Weapon extends PanacheEntityBase {
     public DamageBuffType damageBuffType2;
 
     @OneToMany(mappedBy = "weapon", cascade = CascadeType.ALL, orphanRemoval = true)
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public List<WeaponDetails> details;
 
     public static class PK implements java.io.Serializable {


### PR DESCRIPTION
## Summary
- avoid serializing lazy `details` collections in entities

## Testing
- `mvn -q test` *(fails: Could not resolve artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_688398076d4c832cbb74f41a4c21dcb0