### PR TITLE
Ensure details flush on update

### DIFF
--- a/src/main/java/com/opyruso/coh/resource/AdminCapacityResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCapacityResource.java
@@ -125,6 +125,8 @@ public class AdminCapacityResource {
         details.bonusDescription = payload.bonusDescription;
         details.additionnalDescription = payload.additionnalDescription;
 
+        repository.getEntityManager().flush();
+
         return Response.ok(entity).build();
     }
 

--- a/src/main/java/com/opyruso/coh/resource/AdminCapacityTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCapacityTypeResource.java
@@ -64,6 +64,8 @@ public class AdminCapacityTypeResource {
 
         details.name = payload.name;
 
+        repository.getEntityManager().flush();
+
         return Response.ok(entity).build();
     }
 

--- a/src/main/java/com/opyruso/coh/resource/AdminCharacterResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCharacterResource.java
@@ -66,6 +66,8 @@ public class AdminCharacterResource {
         details.name = payload.name;
         details.story = payload.story;
 
+        repository.getEntityManager().flush();
+
         return Response.ok(entity).build();
     }
 

--- a/src/main/java/com/opyruso/coh/resource/AdminDamageBuffTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminDamageBuffTypeResource.java
@@ -64,6 +64,8 @@ public class AdminDamageBuffTypeResource {
 
         details.name = payload.name;
 
+        repository.getEntityManager().flush();
+
         return Response.ok(entity).build();
     }
 

--- a/src/main/java/com/opyruso/coh/resource/AdminDamageTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminDamageTypeResource.java
@@ -64,6 +64,8 @@ public class AdminDamageTypeResource {
 
         details.name = payload.name;
 
+        repository.getEntityManager().flush();
+
         return Response.ok(entity).build();
     }
 

--- a/src/main/java/com/opyruso/coh/resource/AdminOutfitResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminOutfitResource.java
@@ -70,6 +70,8 @@ public class AdminOutfitResource {
         details.name = payload.name;
         details.description = payload.description;
 
+        repository.getEntityManager().flush();
+
         return Response.ok(entity).build();
     }
 

--- a/src/main/java/com/opyruso/coh/resource/AdminPictoResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminPictoResource.java
@@ -83,6 +83,8 @@ public class AdminPictoResource {
         details.descrptionBonusLumina = payload.descrptionBonusLumina;
         details.unlockDescription = payload.unlockDescription;
 
+        repository.getEntityManager().flush();
+
         return Response.ok(entity).build();
     }
 

--- a/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
@@ -133,6 +133,8 @@ public class AdminWeaponResource {
         details.weaponEffect2 = payload.weaponEffect2;
         details.weaponEffect3 = payload.weaponEffect3;
 
+        repository.getEntityManager().flush();
+
         return Response.ok(entity).build();
     }
 

--- a/src/test/java/com/opyruso/coh/resource/AdminCharacterResourceTest.java
+++ b/src/test/java/com/opyruso/coh/resource/AdminCharacterResourceTest.java
@@ -1,0 +1,68 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.Character;
+import com.opyruso.coh.entity.CharacterDetails;
+import com.opyruso.coh.model.dto.CharacterWithDetails;
+import com.opyruso.coh.repository.CharacterRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+public class AdminCharacterResourceTest {
+
+    @Inject
+    CharacterRepository characterRepository;
+
+    @BeforeEach
+    void setUp() {
+        characterRepository.deleteAll();
+
+        Character c = new Character();
+        c.idCharacter = "c1";
+
+        CharacterDetails cd = new CharacterDetails();
+        cd.idCharacter = "c1";
+        cd.lang = "en";
+        cd.name = "name";
+        cd.character = c;
+
+        c.details = new java.util.ArrayList<>(java.util.List.of(cd));
+        characterRepository.persist(c);
+    }
+
+    @Test
+    @TestSecurity(roles = "admin")
+    public void multipleLangUpdatesInsertDetailsOnly() {
+        CharacterWithDetails dto = new CharacterWithDetails();
+        dto.name = "Nom";
+        dto.story = "Histoire";
+
+        dto.lang = "fr";
+        given()
+                .contentType("application/json")
+                .body(dto)
+                .put("/admin/characters/c1")
+                .then()
+                .statusCode(200);
+
+        Assertions.assertEquals(1, characterRepository.count());
+        Assertions.assertEquals(2, CharacterDetails.count());
+
+        dto.lang = "de";
+        given()
+                .contentType("application/json")
+                .body(dto)
+                .put("/admin/characters/c1")
+                .then()
+                .statusCode(200);
+
+        Assertions.assertEquals(1, characterRepository.count());
+        Assertions.assertEquals(3, CharacterDetails.count());
+    }
+}


### PR DESCRIPTION
## Summary
- flush the entity manager after modifying details in all admin resources
- add a test covering repeated updates with different languages to ensure additional `character_details` rows

## Testing
- `mvn test` *(fails: Non-resolvable import POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6883eaf09030832ca21b2cbb717e192f