### PR TITLE
Update admin operations logic

### DIFF
--- a/src/main/java/com/opyruso/coh/model/dto/PictoWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/PictoWithDetails.java
@@ -2,12 +2,12 @@ package com.opyruso.coh.model.dto;
 
 public class PictoWithDetails {
     public String idPicto;
-    public int level;
-    public int bonusDefense;
-    public int bonusSpeed;
-    public int bonusCritChance;
-    public int bonusHealth;
-    public int luminaCost;
+    public Integer level;
+    public Integer bonusDefense;
+    public Integer bonusSpeed;
+    public Integer bonusCritChance;
+    public Integer bonusHealth;
+    public Integer luminaCost;
     public String lang;
     public String name;
     public String region;

--- a/src/main/java/com/opyruso/coh/resource/AdminCapacityResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminCapacityResource.java
@@ -45,8 +45,14 @@ public class AdminCapacityResource {
             return Response.status(Response.Status.BAD_REQUEST).entity("Invalid capacity type").build();
         }
 
-        Capacity capacity = new Capacity();
-        capacity.idCapacity = payload.idCapacity;
+        Capacity capacity = repository.findById(payload.idCapacity);
+        boolean isNew = false;
+        if (capacity == null) {
+            capacity = new Capacity();
+            capacity.idCapacity = payload.idCapacity;
+            repository.persist(capacity);
+            isNew = true;
+        }
         capacity.character = character;
         capacity.energyCost = payload.energyCost;
         capacity.canBreak = payload.canBreak;
@@ -56,19 +62,36 @@ public class AdminCapacityResource {
         capacity.gridPositionX = payload.gridPositionX;
         capacity.gridPositionY = payload.gridPositionY;
 
+        if (capacity.details == null) {
+            capacity.details = new java.util.ArrayList<>();
+        }
+
         CapacityDetails details = new CapacityDetails();
         details.idCapacity = payload.idCapacity;
         details.lang = payload.lang;
-        details.name = payload.name;
-        details.effectPrimary = payload.effectPrimary;
-        details.effectSecondary = payload.effectSecondary;
-        details.bonusDescription = payload.bonusDescription;
-        details.additionnalDescription = payload.additionnalDescription;
+        if (payload.name != null) {
+            details.name = payload.name;
+        }
+        if (payload.effectPrimary != null) {
+            details.effectPrimary = payload.effectPrimary;
+        }
+        if (payload.effectSecondary != null) {
+            details.effectSecondary = payload.effectSecondary;
+        }
+        if (payload.bonusDescription != null) {
+            details.bonusDescription = payload.bonusDescription;
+        }
+        if (payload.additionnalDescription != null) {
+            details.additionnalDescription = payload.additionnalDescription;
+        }
         details.capacity = capacity;
 
-        capacity.details = new java.util.ArrayList<>(java.util.List.of(details));
+        capacity.details.add(details);
+        if (!isNew) {
+            repository.getEntityManager().persist(details);
+        }
 
-        repository.persist(capacity);
+        repository.getEntityManager().flush();
         return Response.status(Response.Status.CREATED).entity(capacity).build();
     }
 
@@ -82,27 +105,43 @@ public class AdminCapacityResource {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
-        Character character = characterRepository.findById(payload.character);
-        if (character == null) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid character").build();
-        }
-        DamageType damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
-        if (payload.damageType != null && damageType == null) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage type").build();
-        }
-        CapacityType type = payload.type == null ? null : capacityTypeRepository.findById(payload.type);
-        if (payload.type != null && type == null) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid capacity type").build();
+        if (payload.character != null) {
+            Character character = characterRepository.findById(payload.character);
+            if (character == null) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid character").build();
+            }
+            entity.character = character;
         }
 
-        entity.character = character;
-        entity.energyCost = payload.energyCost;
-        entity.canBreak = payload.canBreak;
-        entity.damageType = damageType;
-        entity.type = type;
-        entity.isMultiTarget = payload.isMultiTarget;
-        entity.gridPositionX = payload.gridPositionX;
-        entity.gridPositionY = payload.gridPositionY;
+        if (payload.energyCost != null) {
+            entity.energyCost = payload.energyCost;
+        }
+        if (payload.canBreak != null) {
+            entity.canBreak = payload.canBreak;
+        }
+        if (payload.damageType != null) {
+            DamageType damageType = damageTypeRepository.findById(payload.damageType);
+            if (damageType == null) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage type").build();
+            }
+            entity.damageType = damageType;
+        }
+        if (payload.type != null) {
+            CapacityType type = capacityTypeRepository.findById(payload.type);
+            if (type == null) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid capacity type").build();
+            }
+            entity.type = type;
+        }
+        if (payload.isMultiTarget != null) {
+            entity.isMultiTarget = payload.isMultiTarget;
+        }
+        if (payload.gridPositionX != null) {
+            entity.gridPositionX = payload.gridPositionX;
+        }
+        if (payload.gridPositionY != null) {
+            entity.gridPositionY = payload.gridPositionY;
+        }
 
         if (entity.details == null) {
             entity.details = new java.util.ArrayList<>();
@@ -134,10 +173,26 @@ public class AdminCapacityResource {
     @Path("{id}")
     @RolesAllowed("admin")
     @Transactional
-    public Response delete(@PathParam("id") String id) {
-        boolean deleted = repository.deleteById(id);
-        if (!deleted) {
+    public Response delete(@PathParam("id") String id, @QueryParam("lang") String lang) {
+        Capacity entity = repository.findById(id);
+        if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (lang != null) {
+            if (entity.details != null) {
+                CapacityDetails details = entity.details.stream()
+                        .filter(d -> d.lang.equals(lang))
+                        .findFirst().orElse(null);
+                if (details != null) {
+                    entity.details.remove(details);
+                    repository.getEntityManager().remove(details);
+                }
+            }
+            if (entity.details == null || entity.details.isEmpty()) {
+                repository.delete(entity);
+            }
+        } else {
+            repository.delete(entity);
         }
         return Response.noContent().build();
     }

--- a/src/main/java/com/opyruso/coh/resource/AdminDamageBuffTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminDamageBuffTypeResource.java
@@ -23,8 +23,18 @@ public class AdminDamageBuffTypeResource {
     @RolesAllowed("admin")
     @Transactional
     public Response create(DamageBuffTypeWithDetails payload) {
-        DamageBuffType damageBuffType = new DamageBuffType();
-        damageBuffType.idDamageBuffType = payload.idDamageBuffType;
+        DamageBuffType damageBuffType = repository.findById(payload.idDamageBuffType);
+        boolean isNew = false;
+        if (damageBuffType == null) {
+            damageBuffType = new DamageBuffType();
+            damageBuffType.idDamageBuffType = payload.idDamageBuffType;
+            repository.persist(damageBuffType);
+            isNew = true;
+        }
+
+        if (damageBuffType.details == null) {
+            damageBuffType.details = new java.util.ArrayList<>();
+        }
 
         DamageBuffTypeDetails details = new DamageBuffTypeDetails();
         details.idDamageBuffType = payload.idDamageBuffType;
@@ -32,9 +42,12 @@ public class AdminDamageBuffTypeResource {
         details.name = payload.name;
         details.damageBuffType = damageBuffType;
 
-        damageBuffType.details = new java.util.ArrayList<>(java.util.List.of(details));
+        damageBuffType.details.add(details);
+        if (!isNew) {
+            repository.getEntityManager().persist(details);
+        }
 
-        repository.persist(damageBuffType);
+        repository.getEntityManager().flush();
         return Response.status(Response.Status.CREATED).entity(damageBuffType).build();
     }
 
@@ -62,7 +75,9 @@ public class AdminDamageBuffTypeResource {
                     return d;
                 });
 
-        details.name = payload.name;
+        if (payload.name != null) {
+            details.name = payload.name;
+        }
 
         repository.getEntityManager().flush();
 
@@ -73,10 +88,26 @@ public class AdminDamageBuffTypeResource {
     @Path("{id}")
     @RolesAllowed("admin")
     @Transactional
-    public Response delete(@PathParam("id") String id) {
-        boolean deleted = repository.deleteById(id);
-        if (!deleted) {
+    public Response delete(@PathParam("id") String id, @QueryParam("lang") String lang) {
+        DamageBuffType entity = repository.findById(id);
+        if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (lang != null) {
+            if (entity.details != null) {
+                DamageBuffTypeDetails details = entity.details.stream()
+                        .filter(d -> d.lang.equals(lang))
+                        .findFirst().orElse(null);
+                if (details != null) {
+                    entity.details.remove(details);
+                    repository.getEntityManager().remove(details);
+                }
+            }
+            if (entity.details == null || entity.details.isEmpty()) {
+                repository.delete(entity);
+            }
+        } else {
+            repository.delete(entity);
         }
         return Response.noContent().build();
     }

--- a/src/main/java/com/opyruso/coh/resource/AdminDamageTypeResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminDamageTypeResource.java
@@ -23,8 +23,18 @@ public class AdminDamageTypeResource {
     @RolesAllowed("admin")
     @Transactional
     public Response create(DamageTypeWithDetails payload) {
-        DamageType damageType = new DamageType();
-        damageType.idDamageType = payload.idDamageType;
+        DamageType damageType = repository.findById(payload.idDamageType);
+        boolean isNew = false;
+        if (damageType == null) {
+            damageType = new DamageType();
+            damageType.idDamageType = payload.idDamageType;
+            repository.persist(damageType);
+            isNew = true;
+        }
+
+        if (damageType.details == null) {
+            damageType.details = new java.util.ArrayList<>();
+        }
 
         DamageTypeDetails details = new DamageTypeDetails();
         details.idDamageType = payload.idDamageType;
@@ -32,9 +42,12 @@ public class AdminDamageTypeResource {
         details.name = payload.name;
         details.damageType = damageType;
 
-        damageType.details = new java.util.ArrayList<>(java.util.List.of(details));
+        damageType.details.add(details);
+        if (!isNew) {
+            repository.getEntityManager().persist(details);
+        }
 
-        repository.persist(damageType);
+        repository.getEntityManager().flush();
         return Response.status(Response.Status.CREATED).entity(damageType).build();
     }
 
@@ -62,7 +75,9 @@ public class AdminDamageTypeResource {
                     return d;
                 });
 
-        details.name = payload.name;
+        if (payload.name != null) {
+            details.name = payload.name;
+        }
 
         repository.getEntityManager().flush();
 
@@ -73,10 +88,26 @@ public class AdminDamageTypeResource {
     @Path("{id}")
     @RolesAllowed("admin")
     @Transactional
-    public Response delete(@PathParam("id") String id) {
-        boolean deleted = repository.deleteById(id);
-        if (!deleted) {
+    public Response delete(@PathParam("id") String id, @QueryParam("lang") String lang) {
+        DamageType entity = repository.findById(id);
+        if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (lang != null) {
+            if (entity.details != null) {
+                DamageTypeDetails details = entity.details.stream()
+                        .filter(d -> d.lang.equals(lang))
+                        .findFirst().orElse(null);
+                if (details != null) {
+                    entity.details.remove(details);
+                    repository.getEntityManager().remove(details);
+                }
+            }
+            if (entity.details == null || entity.details.isEmpty()) {
+                repository.delete(entity);
+            }
+        } else {
+            repository.delete(entity);
         }
         return Response.noContent().build();
     }

--- a/src/main/java/com/opyruso/coh/resource/AdminOutfitResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminOutfitResource.java
@@ -24,9 +24,19 @@ public class AdminOutfitResource {
     @RolesAllowed("admin")
     @Transactional
     public Response create(OutfitWithDetails payload) {
-        Outfit outfit = new Outfit();
-        outfit.idOutfit = payload.idOutfit;
+        Outfit outfit = repository.findById(payload.idOutfit);
+        boolean isNew = false;
+        if (outfit == null) {
+            outfit = new Outfit();
+            outfit.idOutfit = payload.idOutfit;
+            repository.persist(outfit);
+            isNew = true;
+        }
         outfit.character = characterRepository.findById(payload.character);
+
+        if (outfit.details == null) {
+            outfit.details = new java.util.ArrayList<>();
+        }
 
         OutfitDetails details = new OutfitDetails();
         details.idOutfit = payload.idOutfit;
@@ -35,9 +45,12 @@ public class AdminOutfitResource {
         details.description = payload.description;
         details.outfit = outfit;
 
-        outfit.details = new java.util.ArrayList<>(java.util.List.of(details));
+        outfit.details.add(details);
+        if (!isNew) {
+            repository.getEntityManager().persist(details);
+        }
 
-        repository.persist(outfit);
+        repository.getEntityManager().flush();
         return Response.status(Response.Status.CREATED).entity(outfit).build();
     }
 
@@ -50,7 +63,9 @@ public class AdminOutfitResource {
         if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        entity.character = characterRepository.findById(payload.character);
+        if (payload.character != null) {
+            entity.character = characterRepository.findById(payload.character);
+        }
 
         if (entity.details == null) {
             entity.details = new java.util.ArrayList<>();
@@ -67,8 +82,12 @@ public class AdminOutfitResource {
                     return d;
                 });
 
-        details.name = payload.name;
-        details.description = payload.description;
+        if (payload.name != null) {
+            details.name = payload.name;
+        }
+        if (payload.description != null) {
+            details.description = payload.description;
+        }
 
         repository.getEntityManager().flush();
 
@@ -79,10 +98,26 @@ public class AdminOutfitResource {
     @Path("{id}")
     @RolesAllowed("admin")
     @Transactional
-    public Response delete(@PathParam("id") String id) {
-        boolean deleted = repository.deleteById(id);
-        if (!deleted) {
+    public Response delete(@PathParam("id") String id, @QueryParam("lang") String lang) {
+        Outfit entity = repository.findById(id);
+        if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (lang != null) {
+            if (entity.details != null) {
+                OutfitDetails details = entity.details.stream()
+                        .filter(d -> d.lang.equals(lang))
+                        .findFirst().orElse(null);
+                if (details != null) {
+                    entity.details.remove(details);
+                    repository.getEntityManager().remove(details);
+                }
+            }
+            if (entity.details == null || entity.details.isEmpty()) {
+                repository.delete(entity);
+            }
+        } else {
+            repository.delete(entity);
         }
         return Response.noContent().build();
     }

--- a/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminWeaponResource.java
@@ -49,13 +49,23 @@ public class AdminWeaponResource {
             return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage buff type 2").build();
         }
 
-        Weapon weapon = new Weapon();
-        weapon.idWeapon = payload.idWeapon;
+        Weapon weapon = repository.findByIdWeapon(payload.idWeapon);
+        boolean isNew = false;
+        if (weapon == null) {
+            weapon = new Weapon();
+            weapon.idWeapon = payload.idWeapon;
+            repository.persist(weapon);
+            isNew = true;
+        }
         weapon.idCharacter = character.idCharacter;
         weapon.character = character;
         weapon.damageType = damageType;
         weapon.damageBuffType1 = damageBuffType1;
         weapon.damageBuffType2 = damageBuffType2;
+
+        if (weapon.details == null) {
+            weapon.details = new java.util.ArrayList<>();
+        }
 
         WeaponDetails details = new WeaponDetails();
         details.idWeapon = payload.idWeapon;
@@ -69,9 +79,12 @@ public class AdminWeaponResource {
         details.weaponEffect3 = payload.weaponEffect3;
         details.weapon = weapon;
 
-        weapon.details = new java.util.ArrayList<>(java.util.List.of(details));
+        weapon.details.add(details);
+        if (!isNew) {
+            repository.getEntityManager().persist(details);
+        }
 
-        repository.persist(weapon);
+        repository.getEntityManager().flush();
         return Response.status(Response.Status.CREATED).entity(weapon).build();
     }
 
@@ -85,28 +98,39 @@ public class AdminWeaponResource {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
-        Character character = characterRepository.findById(payload.character);
-        if (character == null) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid character").build();
-        }
-        DamageType damageType = payload.damageType == null ? null : damageTypeRepository.findById(payload.damageType);
-        if (payload.damageType != null && damageType == null) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage type").build();
-        }
-        DamageBuffType damageBuffType1 = payload.damageBuffType1 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType1);
-        if (payload.damageBuffType1 != null && damageBuffType1 == null) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage buff type 1").build();
-        }
-        DamageBuffType damageBuffType2 = payload.damageBuffType2 == null ? null : damageBuffTypeRepository.findById(payload.damageBuffType2);
-        if (payload.damageBuffType2 != null && damageBuffType2 == null) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage buff type 2").build();
+        Character character = entity.character;
+        if (payload.character != null) {
+            character = characterRepository.findById(payload.character);
+            if (character == null) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid character").build();
+            }
+            entity.idCharacter = character.idCharacter;
+            entity.character = character;
         }
 
-        entity.idCharacter = character.idCharacter;
-        entity.character = character;
-        entity.damageType = damageType;
-        entity.damageBuffType1 = damageBuffType1;
-        entity.damageBuffType2 = damageBuffType2;
+        if (payload.damageType != null) {
+            DamageType damageType = damageTypeRepository.findById(payload.damageType);
+            if (damageType == null) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage type").build();
+            }
+            entity.damageType = damageType;
+        }
+
+        if (payload.damageBuffType1 != null) {
+            DamageBuffType damageBuffType1 = damageBuffTypeRepository.findById(payload.damageBuffType1);
+            if (damageBuffType1 == null) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage buff type 1").build();
+            }
+            entity.damageBuffType1 = damageBuffType1;
+        }
+
+        if (payload.damageBuffType2 != null) {
+            DamageBuffType damageBuffType2 = damageBuffTypeRepository.findById(payload.damageBuffType2);
+            if (damageBuffType2 == null) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid damage buff type 2").build();
+            }
+            entity.damageBuffType2 = damageBuffType2;
+        }
 
         if (entity.details == null) {
             entity.details = new java.util.ArrayList<>();
@@ -126,12 +150,24 @@ public class AdminWeaponResource {
 
         details.idCharacter = character.idCharacter;
 
-        details.name = payload.name;
-        details.region = payload.region;
-        details.unlockDescription = payload.unlockDescription;
-        details.weaponEffect1 = payload.weaponEffect1;
-        details.weaponEffect2 = payload.weaponEffect2;
-        details.weaponEffect3 = payload.weaponEffect3;
+        if (payload.name != null) {
+            details.name = payload.name;
+        }
+        if (payload.region != null) {
+            details.region = payload.region;
+        }
+        if (payload.unlockDescription != null) {
+            details.unlockDescription = payload.unlockDescription;
+        }
+        if (payload.weaponEffect1 != null) {
+            details.weaponEffect1 = payload.weaponEffect1;
+        }
+        if (payload.weaponEffect2 != null) {
+            details.weaponEffect2 = payload.weaponEffect2;
+        }
+        if (payload.weaponEffect3 != null) {
+            details.weaponEffect3 = payload.weaponEffect3;
+        }
 
         repository.getEntityManager().flush();
 
@@ -142,10 +178,26 @@ public class AdminWeaponResource {
     @Path("{id}")
     @RolesAllowed("admin")
     @Transactional
-    public Response delete(@PathParam("id") String id) {
-        boolean deleted = repository.deleteByIdWeapon(id);
-        if (!deleted) {
+    public Response delete(@PathParam("id") String id, @QueryParam("lang") String lang) {
+        Weapon entity = repository.findByIdWeapon(id);
+        if (entity == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (lang != null) {
+            if (entity.details != null) {
+                WeaponDetails details = entity.details.stream()
+                        .filter(d -> d.lang.equals(lang))
+                        .findFirst().orElse(null);
+                if (details != null) {
+                    entity.details.remove(details);
+                    repository.getEntityManager().remove(details);
+                }
+            }
+            if (entity.details == null || entity.details.isEmpty()) {
+                repository.delete(entity);
+            }
+        } else {
+            repository.delete(entity);
         }
         return Response.noContent().build();
     }


### PR DESCRIPTION
## Summary
- allow POST to add translations without duplicating primary records
- support partial updates in all admin resources
- delete details by language and remove entity when empty
- keep numeric picto fields nullable for partial updates

## Testing
- `mvn -q -DskipTests package` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68842ccc7c60832cadc196ce310d880c