### PR TITLE
Add contributor endpoints and build management

### DIFF
--- a/src/main/java/com/opyruso/coh/entity/CohBuild.java
+++ b/src/main/java/com/opyruso/coh/entity/CohBuild.java
@@ -18,4 +18,19 @@ public class CohBuild extends PanacheEntityBase {
     @Lob
     @Column(name = "content")
     public String content;
+
+    @Column(name = "author")
+    public String author;
+
+    @Column(name = "firstname")
+    public String firstname;
+
+    @Column(name = "title")
+    public String title;
+
+    @Column(name = "recommended_level")
+    public Integer recommendedLevel;
+
+    @Column(name = "description")
+    public String description;
 }

--- a/src/main/java/com/opyruso/coh/entity/OutfitDetails.java
+++ b/src/main/java/com/opyruso/coh/entity/OutfitDetails.java
@@ -18,8 +18,11 @@ public class OutfitDetails extends PanacheEntityBase {
     @Column(name = "lang")
     public String lang;
 
-    @Column(name = "description")
-    public String description;
+    @Column(name = "region")
+    public String region;
+
+    @Column(name = "unlock_description")
+    public String unlockDescription;
 
     @ManyToOne
     @JoinColumn(name = "id_outfit", insertable = false, updatable = false)

--- a/src/main/java/com/opyruso/coh/model/dto/BuildPayload.java
+++ b/src/main/java/com/opyruso/coh/model/dto/BuildPayload.java
@@ -1,0 +1,8 @@
+package com.opyruso.coh.model.dto;
+
+public class BuildPayload {
+    public String title;
+    public String description;
+    public Integer recommendedLevel;
+    public String content;
+}

--- a/src/main/java/com/opyruso/coh/model/dto/OutfitWithDetails.java
+++ b/src/main/java/com/opyruso/coh/model/dto/OutfitWithDetails.java
@@ -5,5 +5,6 @@ public class OutfitWithDetails {
     public String character;
     public String lang;
     public String name;
-    public String description;
+    public String region;
+    public String unlockDescription;
 }

--- a/src/main/java/com/opyruso/coh/resource/AdminOutfitResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminOutfitResource.java
@@ -37,14 +37,15 @@ public class AdminOutfitResource {
             outfit.name = payload.name;
         }
 
-        if (payload.description != null) {
+        if (payload.region != null || payload.unlockDescription != null) {
             if (outfit.details == null) {
                 outfit.details = new java.util.ArrayList<>();
             }
             OutfitDetails details = new OutfitDetails();
             details.idOutfit = payload.idOutfit;
             details.lang = payload.lang;
-            details.description = payload.description;
+            details.region = payload.region;
+            details.unlockDescription = payload.unlockDescription;
             details.outfit = outfit;
             outfit.details.add(details);
             if (!isNew) {
@@ -72,10 +73,10 @@ public class AdminOutfitResource {
         if (payload.name != null) {
             entity.name = payload.name;
         }
-        if (payload.description != null) {
+        if (payload.region != null || payload.unlockDescription != null) {
             if (payload.lang == null) {
                 return Response.status(Response.Status.BAD_REQUEST)
-                        .entity("lang is required when updating description")
+                        .entity("lang is required when updating details")
                         .build();
             }
             if (entity.details == null) {
@@ -92,7 +93,12 @@ public class AdminOutfitResource {
                         entity.details.add(d);
                         return d;
                     });
-            details.description = payload.description;
+            if (payload.region != null) {
+                details.region = payload.region;
+            }
+            if (payload.unlockDescription != null) {
+                details.unlockDescription = payload.unlockDescription;
+            }
         }
 
         repository.getEntityManager().flush();

--- a/src/main/java/com/opyruso/coh/resource/BuildResource.java
+++ b/src/main/java/com/opyruso/coh/resource/BuildResource.java
@@ -1,0 +1,85 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.CohBuild;
+import com.opyruso.coh.model.dto.BuildPayload;
+import com.opyruso.coh.repository.CohBuildRepository;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.UUID;
+
+@Path("/builds")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Authenticated
+public class BuildResource {
+
+    @Inject
+    CohBuildRepository repository;
+
+    @Inject
+    SecurityIdentity identity;
+
+    private String generateKey() {
+        return UUID.randomUUID().toString();
+    }
+
+    @POST
+    @Transactional
+    public Response create(BuildPayload payload) {
+        String id = generateKey();
+        CohBuild build = new CohBuild();
+        build.idBuild = id;
+        build.author = identity.getPrincipal().getName();
+        Object fn = identity.getAttribute("given_name");
+        build.firstname = fn != null ? fn.toString() : null;
+        build.title = payload.title;
+        build.description = payload.description;
+        build.recommendedLevel = payload.recommendedLevel;
+        build.content = Base64.getEncoder().encodeToString(payload.content.getBytes(StandardCharsets.UTF_8));
+        repository.persist(build);
+        return Response.status(Response.Status.CREATED).entity(Map.of("id", id)).build();
+    }
+
+    @PUT
+    @Path("{id}")
+    @Transactional
+    public Response update(@PathParam("id") String id, BuildPayload payload) {
+        CohBuild build = repository.findById(id);
+        if (build == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (!identity.getPrincipal().getName().equals(build.author)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        if (payload.title != null) build.title = payload.title;
+        if (payload.description != null) build.description = payload.description;
+        if (payload.recommendedLevel != null) build.recommendedLevel = payload.recommendedLevel;
+        if (payload.content != null) build.content = Base64.getEncoder().encodeToString(payload.content.getBytes(StandardCharsets.UTF_8));
+        repository.getEntityManager().flush();
+        return Response.ok().build();
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Transactional
+    public Response delete(@PathParam("id") String id) {
+        CohBuild build = repository.findById(id);
+        if (build == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (!identity.getPrincipal().getName().equals(build.author)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        repository.delete(build);
+        return Response.noContent().build();
+    }
+}

--- a/src/main/java/com/opyruso/coh/resource/ContributorOutfitResource.java
+++ b/src/main/java/com/opyruso/coh/resource/ContributorOutfitResource.java
@@ -1,0 +1,61 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.Outfit;
+import com.opyruso.coh.entity.OutfitDetails;
+import com.opyruso.coh.repository.OutfitRepository;
+import com.opyruso.coh.model.dto.OutfitWithDetails;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/contrib/outfits")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class ContributorOutfitResource {
+
+    @Inject
+    OutfitRepository repository;
+
+    @PUT
+    @Path("{id}")
+    @RolesAllowed("contributor")
+    @Transactional
+    public Response update(@PathParam("id") String id, OutfitWithDetails payload) {
+        Outfit entity = repository.findById(id);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (payload.region != null || payload.unlockDescription != null) {
+            if (payload.lang == null) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("lang is required when updating details")
+                        .build();
+            }
+            if (entity.details == null) {
+                entity.details = new java.util.ArrayList<>();
+            }
+            OutfitDetails details = entity.details.stream()
+                    .filter(d -> d.lang.equals(payload.lang))
+                    .findFirst()
+                    .orElseGet(() -> {
+                        OutfitDetails d = new OutfitDetails();
+                        d.idOutfit = id;
+                        d.lang = payload.lang;
+                        d.outfit = entity;
+                        entity.details.add(d);
+                        return d;
+                    });
+            if (payload.region != null) {
+                details.region = payload.region;
+            }
+            if (payload.unlockDescription != null) {
+                details.unlockDescription = payload.unlockDescription;
+            }
+        }
+        repository.getEntityManager().flush();
+        return Response.ok(entity).build();
+    }
+}

--- a/src/main/java/com/opyruso/coh/resource/ContributorPictoResource.java
+++ b/src/main/java/com/opyruso/coh/resource/ContributorPictoResource.java
@@ -1,0 +1,65 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.Picto;
+import com.opyruso.coh.entity.PictoDetails;
+import com.opyruso.coh.repository.PictoRepository;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import com.opyruso.coh.model.dto.PictoWithDetails;
+
+@Path("/contrib/pictos")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class ContributorPictoResource {
+
+    @Inject
+    PictoRepository repository;
+
+    @PUT
+    @Path("{id}")
+    @RolesAllowed("contributor")
+    @Transactional
+    public Response update(@PathParam("id") String id, PictoWithDetails payload) {
+        Picto entity = repository.findById(id);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (payload.level != null) {
+            entity.level = payload.level;
+        }
+        if (payload.region != null || payload.unlockDescription != null) {
+            if (payload.lang == null) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("lang is required when updating details")
+                        .build();
+            }
+            if (entity.details == null) {
+                entity.details = new java.util.ArrayList<>();
+            }
+            PictoDetails details = entity.details.stream()
+                    .filter(d -> d.lang.equals(payload.lang))
+                    .findFirst()
+                    .orElseGet(() -> {
+                        PictoDetails d = new PictoDetails();
+                        d.idPicto = id;
+                        d.lang = payload.lang;
+                        d.picto = entity;
+                        entity.details.add(d);
+                        return d;
+                    });
+            if (payload.region != null) {
+                details.region = payload.region;
+            }
+            if (payload.unlockDescription != null) {
+                details.unlockDescription = payload.unlockDescription;
+            }
+        }
+        repository.getEntityManager().flush();
+        return Response.ok(entity).build();
+    }
+}

--- a/src/main/java/com/opyruso/coh/resource/ContributorWeaponResource.java
+++ b/src/main/java/com/opyruso/coh/resource/ContributorWeaponResource.java
@@ -1,0 +1,68 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.Weapon;
+import com.opyruso.coh.entity.WeaponDetails;
+import com.opyruso.coh.repository.WeaponRepository;
+import com.opyruso.coh.model.dto.WeaponWithDetails;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/contrib/weapons")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class ContributorWeaponResource {
+
+    @Inject
+    WeaponRepository repository;
+
+    @PUT
+    @Path("{id}")
+    @RolesAllowed("contributor")
+    @Transactional
+    public Response update(@PathParam("id") String id, WeaponWithDetails payload) {
+        if (payload.character == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("character is required")
+                    .build();
+        }
+        Weapon entity = repository.findByIdWeaponAndCharacter(id, payload.character);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (payload.region != null || payload.unlockDescription != null) {
+            if (payload.lang == null) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("lang is required when updating details")
+                        .build();
+            }
+            if (entity.details == null) {
+                entity.details = new java.util.ArrayList<>();
+            }
+            WeaponDetails details = entity.details.stream()
+                    .filter(d -> d.lang.equals(payload.lang))
+                    .findFirst()
+                    .orElseGet(() -> {
+                        WeaponDetails d = new WeaponDetails();
+                        d.idWeapon = id;
+                        d.idCharacter = payload.character;
+                        d.lang = payload.lang;
+                        d.weapon = entity;
+                        entity.details.add(d);
+                        return d;
+                    });
+            details.idCharacter = payload.character;
+            if (payload.region != null) {
+                details.region = payload.region;
+            }
+            if (payload.unlockDescription != null) {
+                details.unlockDescription = payload.unlockDescription;
+            }
+        }
+        repository.getEntityManager().flush();
+        return Response.ok(entity).build();
+    }
+}

--- a/src/main/java/com/opyruso/coh/resource/PublicDataResource.java
+++ b/src/main/java/com/opyruso/coh/resource/PublicDataResource.java
@@ -160,7 +160,13 @@ public class PublicDataResource {
             dto.character = o.character != null ? o.character.idCharacter : null;
             dto.lang = lang;
             dto.name = o.name != null ? o.name : "";
-            dto.description = od != null ? od.description : "";
+            if (od != null) {
+                dto.region = od.region;
+                dto.unlockDescription = od.unlockDescription;
+            } else {
+                dto.region = "";
+                dto.unlockDescription = "";
+            }
             return dto;
         }).toList();
 


### PR DESCRIPTION
## Summary
- add region and rename unlockDescription in outfit details
- expand `CohBuild` with author, firstname, title, level and description fields
- adjust DTOs and public data loading
- provide contributor resources for pictos, outfits and weapons
- implement authenticated build management

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886dd340c80832c95d3c1620ceb7a3d