### PR TITLE
Ensure Keycloak ID saved as author

### DIFF
--- a/src/main/java/com/opyruso/coh/resource/BuildResource.java
+++ b/src/main/java/com/opyruso/coh/resource/BuildResource.java
@@ -30,8 +30,7 @@ public class BuildResource {
     SecurityIdentity identity;
 
     private String getUserId() {
-        Object sub = identity.getAttribute("sub");
-        return sub != null ? sub.toString() : identity.getPrincipal().getName();
+        return identity.getPrincipal().getName();
     }
 
     private String generateKey() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,7 @@ quarkus.vertx.web-client.enable=true
 
 quarkus.oidc.auth-server-url=https://auth.opyruso.com/realms/development
 quarkus.oidc.client-id=coh-app
+quarkus.oidc.token.principal-claim=sub
 
 # HTTP CORS configuration
 quarkus.http.cors=true


### PR DESCRIPTION
## Summary
- map the security principal name directly in `BuildResource`
- configure OIDC to use `sub` as the principal claim

## Testing
- `mvn test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886f7b9b1e8832c8bf90d6cdbe58520