### PR TITLE
Add query filter for latest builds

### DIFF
--- a/src/main/java/com/opyruso/coh/resource/PublicResource.java
+++ b/src/main/java/com/opyruso/coh/resource/PublicResource.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -57,8 +58,12 @@ public class PublicResource {
 
     @GET
     @Path("latest")
-    public Response latest() {
-        var list = repository.findAll(Sort.descending("creationDate")).page(Page.ofSize(10)).list()
+    public Response latest(@QueryParam("q") String query) {
+        var stream = (query == null || query.isBlank())
+                ? repository.findAll(Sort.descending("creationDate"))
+                : repository.find("(lower(description) like ?1 or lower(firstname) like ?1)",
+                        Sort.descending("creationDate"), "%" + query.toLowerCase() + "%");
+        var list = stream.page(Page.ofSize(10)).list()
                 .stream()
                 .map(b -> Map.of(
                         "id", b.idBuild,


### PR DESCRIPTION
## Summary
- update `PublicResource` to add a `q` query parameter to `/public/builds/latest`
- filter by description or firstname using the new parameter

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887d739ea48832cbb4d9d22a5bd2221