### PR TITLE
Handle null values in latest build listing

### DIFF
--- a/src/main/java/com/opyruso/coh/resource/PublicResource.java
+++ b/src/main/java/com/opyruso/coh/resource/PublicResource.java
@@ -66,15 +66,19 @@ public class PublicResource {
         var list = stream.page(Page.ofSize(10)).list()
                 .stream()
                 .map(b -> Map.of(
-                        "id", b.idBuild,
-                        "title", b.title,
-                        "description", b.description,
-                        "recommendedLevel", b.recommendedLevel,
-                        "author", b.author,
-                        "firstname", b.firstname,
-                        "creationDate", b.creationDate))
+                        "id", orBlank(b.idBuild),
+                        "title", orBlank(b.title),
+                        "description", orBlank(b.description),
+                        "recommendedLevel", orBlank(b.recommendedLevel),
+                        "author", orBlank(b.author),
+                        "firstname", orBlank(b.firstname),
+                        "creationDate", orBlank(b.creationDate)))
                 .toList();
         return Response.ok(list).build();
+    }
+
+    private static Object orBlank(Object value) {
+        return value != null ? value : "";
     }
 
     private String generateKey() {

--- a/src/test/java/com/opyruso/coh/resource/PublicResourceTest.java
+++ b/src/test/java/com/opyruso/coh/resource/PublicResourceTest.java
@@ -1,0 +1,41 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.CohBuild;
+import com.opyruso.coh.repository.CohBuildRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class PublicResourceTest {
+
+    @Inject
+    CohBuildRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+
+        CohBuild b = new CohBuild();
+        b.idBuild = "b1";
+        b.content = ""; // minimal content
+        repository.persist(b);
+    }
+
+    @Test
+    public void latestReplacesNullWithBlank() {
+        given()
+                .get("/public/builds/latest")
+                .then()
+                .statusCode(200)
+                .body("[0].title", is(""))
+                .body("[0].description", is(""))
+                .body("[0].recommendedLevel", is(""))
+                .body("[0].author", is(""))
+                .body("[0].firstname", is(""));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure null fields from `CohBuild` are replaced with empty strings in `PublicResource`
- add unit test for `/public/builds/latest` handling of nulls

## Testing
- `mvn -q test` *(fails: `Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.10.0`)

------
https://chatgpt.com/codex/tasks/task_e_6888350fa804832cb9fa3ab5058f32dc