### PR TITLE
Filter out anonymous builds

### DIFF
--- a/src/main/java/com/opyruso/coh/resource/PublicResource.java
+++ b/src/main/java/com/opyruso/coh/resource/PublicResource.java
@@ -60,8 +60,8 @@ public class PublicResource {
     @Path("latest")
     public Response latest(@QueryParam("q") String query) {
         var stream = (query == null || query.isBlank())
-                ? repository.findAll(Sort.descending("creationDate"))
-                : repository.find("(lower(description) like ?1 or lower(firstname) like ?1)",
+                ? repository.find("author is not null", Sort.descending("creationDate"))
+                : repository.find("author is not null and (lower(description) like ?1 or lower(firstname) like ?1)",
                         Sort.descending("creationDate"), "%" + query.toLowerCase() + "%");
         var list = stream.page(Page.ofSize(10)).list()
                 .stream()

--- a/src/test/java/com/opyruso/coh/resource/PublicResourceTest.java
+++ b/src/test/java/com/opyruso/coh/resource/PublicResourceTest.java
@@ -27,15 +27,11 @@ public class PublicResourceTest {
     }
 
     @Test
-    public void latestReplacesNullWithBlank() {
+    public void latestIgnoresAnonymousBuilds() {
         given()
                 .get("/public/builds/latest")
                 .then()
                 .statusCode(200)
-                .body("[0].title", is(""))
-                .body("[0].description", is(""))
-                .body("[0].recommendedLevel", is(""))
-                .body("[0].author", is(""))
-                .body("[0].firstname", is(""));
+                .body("size()", is(0));
     }
 }


### PR DESCRIPTION
## Summary
- hide anonymous builds when listing latest public builds
- update test for new behavior

## Testing
- `mvn -q test` *(fails: couldn't download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a60b53610832cb8e116d45e431ecf