### PR TITLE
Add suggestion endpoints

### DIFF
--- a/src/main/java/com/opyruso/coh/entity/Suggestion.java
+++ b/src/main/java/com/opyruso/coh/entity/Suggestion.java
@@ -1,0 +1,29 @@
+package com.opyruso.coh.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "suggestions")
+public class Suggestion extends AuditableEntity {
+
+    @Id
+    @Column(name = "id_suggestion")
+    public String idSuggestion;
+
+    @Column(name = "user_id")
+    public String userId;
+
+    @Column(name = "type")
+    public String type;
+
+    @Column(name = "title")
+    public String title;
+
+    @Lob
+    @Column(name = "description")
+    public String description;
+}

--- a/src/main/java/com/opyruso/coh/repository/SuggestionRepository.java
+++ b/src/main/java/com/opyruso/coh/repository/SuggestionRepository.java
@@ -1,0 +1,9 @@
+package com.opyruso.coh.repository;
+
+import com.opyruso.coh.entity.Suggestion;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SuggestionRepository implements PanacheRepositoryBase<Suggestion, String> {
+}

--- a/src/main/java/com/opyruso/coh/resource/AdminSuggestionResource.java
+++ b/src/main/java/com/opyruso/coh/resource/AdminSuggestionResource.java
@@ -1,0 +1,41 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.Suggestion;
+import com.opyruso.coh.repository.SuggestionRepository;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+
+@Path("/admin/suggestions")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class AdminSuggestionResource {
+
+    @Inject
+    SuggestionRepository repository;
+
+    @GET
+    @RolesAllowed("admin")
+    public Response list() {
+        List<Suggestion> suggestions = repository.listAll();
+        return Response.ok(suggestions).build();
+    }
+
+    @DELETE
+    @Path("{id}")
+    @RolesAllowed("admin")
+    @Transactional
+    public Response delete(@PathParam("id") String id) {
+        Suggestion suggestion = repository.findById(id);
+        if (suggestion == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        repository.delete(suggestion);
+        return Response.noContent().build();
+    }
+}

--- a/src/main/java/com/opyruso/coh/resource/SuggestionResource.java
+++ b/src/main/java/com/opyruso/coh/resource/SuggestionResource.java
@@ -1,0 +1,59 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.Suggestion;
+import com.opyruso.coh.repository.SuggestionRepository;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Path("/suggestions")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Authenticated
+public class SuggestionResource {
+
+    public static class SuggestionPayload {
+        public String type;
+        public String title;
+        public String description;
+    }
+
+    @Inject
+    SuggestionRepository repository;
+
+    @Inject
+    SecurityIdentity identity;
+
+    private String getUserId() {
+        return identity.getPrincipal().getName();
+    }
+
+    private String generateKey() {
+        return UUID.randomUUID().toString();
+    }
+
+    @POST
+    @Transactional
+    public Response create(SuggestionPayload payload) {
+        Suggestion suggestion = new Suggestion();
+        suggestion.idSuggestion = generateKey();
+        suggestion.userId = getUserId();
+        suggestion.type = payload.type;
+        suggestion.title = payload.title;
+        suggestion.description = payload.description;
+        repository.persist(suggestion);
+        return Response.status(Response.Status.CREATED)
+                .entity(Map.of("id", suggestion.idSuggestion))
+                .build();
+    }
+}

--- a/src/test/java/com/opyruso/coh/resource/AdminSuggestionResourceTest.java
+++ b/src/test/java/com/opyruso/coh/resource/AdminSuggestionResourceTest.java
@@ -1,0 +1,52 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.entity.Suggestion;
+import com.opyruso.coh.repository.SuggestionRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+public class AdminSuggestionResourceTest {
+
+    @Inject
+    SuggestionRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+        Suggestion s = new Suggestion();
+        s.idSuggestion = "s1";
+        s.userId = "u1";
+        s.type = "Bug";
+        s.title = "t";
+        s.description = "d";
+        repository.persist(s);
+    }
+
+    @Test
+    @TestSecurity(roles = "admin")
+    public void listSuggestions() {
+        given()
+          .get("/admin/suggestions")
+          .then()
+          .statusCode(200)
+          .body("size()", org.hamcrest.Matchers.equalTo(1));
+    }
+
+    @Test
+    @TestSecurity(roles = "admin")
+    public void deleteSuggestion() {
+        given()
+          .delete("/admin/suggestions/s1")
+          .then()
+          .statusCode(204);
+
+        Assertions.assertEquals(0, repository.count());
+    }
+}

--- a/src/test/java/com/opyruso/coh/resource/SuggestionResourceTest.java
+++ b/src/test/java/com/opyruso/coh/resource/SuggestionResourceTest.java
@@ -1,0 +1,47 @@
+package com.opyruso.coh.resource;
+
+import com.opyruso.coh.repository.SuggestionRepository;
+import com.opyruso.coh.entity.Suggestion;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+public class SuggestionResourceTest {
+
+    @Inject
+    SuggestionRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Test
+    @TestSecurity(user = "u1")
+    public void createSuggestion() {
+        var payload = new java.util.HashMap<String, String>();
+        payload.put("type", "Bug");
+        payload.put("title", "Issue");
+        payload.put("description", "desc");
+
+        given()
+          .contentType("application/json")
+          .body(payload)
+          .post("/suggestions")
+          .then()
+          .statusCode(201)
+          .body("id", org.hamcrest.Matchers.notNullValue());
+
+        org.junit.jupiter.api.Assertions.assertEquals(1, repository.count());
+        Suggestion s = repository.findAll().firstResult();
+        org.junit.jupiter.api.Assertions.assertEquals("u1", s.userId);
+        org.junit.jupiter.api.Assertions.assertEquals("Bug", s.type);
+        org.junit.jupiter.api.Assertions.assertEquals("Issue", s.title);
+        org.junit.jupiter.api.Assertions.assertEquals("desc", s.description);
+    }
+}


### PR DESCRIPTION
## Summary
- add Suggestion entity and repository
- add POST endpoint for suggestions
- add admin endpoints to list and delete suggestions
- test new functionality

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688b136aa7ec832cac52a36832acdcfc