### PR TITLE
Handle build updates or fork creation based on payload id

### DIFF
--- a/src/main/java/com/opyruso/coh/entity/CohBuild.java
+++ b/src/main/java/com/opyruso/coh/entity/CohBuild.java
@@ -32,4 +32,7 @@ public class CohBuild extends AuditableEntity {
 
     @Column(name = "description")
     public String description;
+
+    @Column(name = "build_origin")
+    public String buildOrigin;
 }

--- a/src/main/java/com/opyruso/coh/model/dto/BuildPayload.java
+++ b/src/main/java/com/opyruso/coh/model/dto/BuildPayload.java
@@ -1,6 +1,7 @@
 package com.opyruso.coh.model.dto;
 
 public class BuildPayload {
+    public String id;
     public String title;
     public String description;
     public Integer recommendedLevel;


### PR DESCRIPTION
## Summary
- allow POST /builds to update an existing build owned by the caller when `id` is supplied
- create new builds with a `build_origin` reference when `id` is missing or not owned
- add tests for updating and forking behavior

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688c16add40c832c85b76eac7a93a84b